### PR TITLE
Fix: ESLint unused variable warnings

### DIFF
--- a/src/commands/previewCommand.ts
+++ b/src/commands/previewCommand.ts
@@ -177,7 +177,7 @@ function findMainHtmlFile(outputDir: string, baseName: string): string | null {
         if (htmlFiles.length > 0) {
             return path.join(outputDir, htmlFiles[0]);
         }
-    } catch (error) {
+    } catch (_error) {
         // Directory doesn't exist or can't be read
     }
 

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -14,7 +14,7 @@ async function main() {
 
         // Download VS Code, unzip it and run the integration test
         await runTests({ extensionDevelopmentPath, extensionTestsPath });
-    } catch (err) {
+    } catch (_err) {
         console.error('Failed to run tests');
         process.exit(1);
     }

--- a/src/test/suite/commandAndDetection.test.ts
+++ b/src/test/suite/commandAndDetection.test.ts
@@ -109,7 +109,7 @@ suite('Command and Auto-Detection Test Suite', () => {
 
                 // Command should complete without error (even though it doesn't validate)
                 assert.ok(true, 'Should handle non-DITA file gracefully');
-            } catch (error) {
+            } catch (_error) {
                 // File might not exist, which is fine
                 assert.ok(true, 'Non-DITA file test completed');
             }

--- a/src/utils/ditaOtWrapper.ts
+++ b/src/utils/ditaOtWrapper.ts
@@ -125,7 +125,7 @@ export class DitaOtWrapper {
                 version: version,
                 path: this.ditaOtCommand || 'System PATH'
             };
-        } catch (error) {
+        } catch (_error) {
             return {
                 installed: false
             };
@@ -158,7 +158,7 @@ export class DitaOtWrapper {
             }
 
             return transtypes.sort();
-        } catch (error) {
+        } catch (_error) {
             // Return default transtypes if command fails
             return ['html5', 'pdf', 'xhtml', 'epub', 'htmlhelp', 'markdown'];
         }


### PR DESCRIPTION
Fixed 5 unused variable warnings by prefixing with underscore:
- previewCommand.ts:180 - catch (error) -> catch (_error)
- runTest.ts:17 - catch (err) -> catch (_err)
- commandAndDetection.test.ts:112 - catch (error) -> catch (_error)
- ditaOtWrapper.ts:128 - catch (error) -> catch (_error)
- ditaOtWrapper.ts:161 - catch (error) -> catch (_error)

This follows the ESLint rule argsIgnorePattern: '^_' to indicate intentionally unused parameters in catch blocks.