### PR TITLE
Add VSIX artifact build to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,3 +38,19 @@ jobs:
     - name: Run tests
       run: xvfb-run -a npm test
       if: success()
+
+    - name: Install vsce
+      run: npm install -g @vscode/vsce
+      if: success()
+
+    - name: Package extension
+      run: vsce package
+      if: success()
+
+    - name: Upload VSIX artifact
+      uses: actions/upload-artifact@v4
+      if: success()
+      with:
+        name: ditacraft-${{ github.sha }}-vsix
+        path: '*.vsix'
+        retention-days: 30


### PR DESCRIPTION
- Install @vscode/vsce globally in CI
- Package extension to create .vsix file
- Upload VSIX as artifact with 30-day retention
- Artifact name includes commit SHA for easy identification