### PR TITLE
feat: implement DITA key space improvements (scope qualification, PushDown, inline scopes)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,307 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+**DitaCraft** is a comprehensive VS Code extension for editing and publishing DITA (Darwin Information Typing Architecture) XML files. It provides syntax highlighting, real-time validation, smart navigation, LSP-based IntelliSense, live HTML preview, and one-click DITA-OT publishing. The project uses a **client-server architecture**: the client extension handles UI commands and a separate LSP server handles all language intelligence.
+
+**Key Stats:**
+- 1,376+ tests (683 client + 703 server)
+- 23,000+ lines of TypeScript code
+- Client: ES2020, CommonJS, esbuild bundled
+- Server: 13-phase validation pipeline, LSP 3.17+
+- Validation: TypesXML DTD (OASIS catalog), optional RelaxNG, 43 DITA rules, custom regex rules
+
+---
+
+## Building & Development
+
+### Install Dependencies
+```bash
+npm install
+```
+
+### Compile (Client + Server)
+```bash
+npm run compile
+```
+Runs type checking and esbuild for both client and server. Produces `out/extension.js` and `server/out/server.js`.
+
+### Development Watch Mode (Recommended)
+```bash
+npm run watch
+```
+Runs esbuild and TypeScript in watch mode. Press **F5** in VS Code to launch in debug mode. Reload with **Ctrl+R** to test changes.
+
+### Linting
+```bash
+npm run lint
+```
+ESLint with TypeScript support. Uses `@typescript-eslint/parser` and `.eslintrc.json`.
+
+---
+
+## Testing
+
+### Client Tests (VS Code Integration)
+```bash
+npm test
+```
+Runs integration tests using `@vscode/test-electron`. Timeout: 10 seconds per test.
+
+To run a single test: Modify `src/test/suite/index.ts` to filter tests by name.
+
+### Server Tests (Standalone Mocha, No VS Code)
+```bash
+cd server
+npm test
+```
+Compiles TypeScript and runs Mocha: `mocha out/test/**/*.test.js --ui tdd --timeout 10000`
+
+To run a single server test:
+```bash
+cd server
+npm test -- --grep "test suite name"
+```
+Example: `npm test -- --grep "validateDITADocument"`
+
+### Code Coverage
+
+**Client:**
+```bash
+npm run coverage
+```
+Enforces: 63% lines, 63% statements, 70% functions, 73% branches.
+
+**Server:**
+```bash
+cd server && npm run coverage
+```
+Enforces: 90% lines/statements/functions, 80% branches.
+
+---
+
+## Project Architecture
+
+### High-Level Structure
+
+**Client-Server Architecture:**
+- **Client** (`src/`) — VS Code extension: commands, UI views, file operations, configuration
+- **LSP Server** (`server/src/`) — Separate Node.js process via IPC: validation, IntelliSense, navigation, formatting
+
+The client starts the server as a child process. They communicate via LSP 3.17+ (JSON-RPC over stdio).
+
+**Key Integration Points:**
+- `src/languageClient.ts` — Initializes LSP client, manages connection
+- `server/src/server.ts` — LSP server entry point, registers all feature handlers
+- Validation runs in pull-based diagnostics: client requests → server's `ValidationPipeline` runs 13 phases → returns `Diagnostic[]`
+
+### Validation Pipeline (13 Phases)
+
+The `ValidationPipeline` in `server/src/services/validationPipeline.ts` orchestrates all validation with error isolation (if phase 6 crashes, phases 7-13 still run):
+
+1. XML well-formedness (fast-xml-parser)
+2. DITA structure (root, DOCTYPE, required children)
+3. ID validation (duplicates, format, quote consistency)
+4. Content model validation
+5. DTD validation (TypesXML + OASIS catalog) OR RelaxNG (salve-annos)
+6. DITA rules (43 Schematron-equivalent rules, version-gated)
+7. Custom rules (user-defined regex patterns)
+8. Cross-reference validation (href/conref/keyref targets exist)
+9. Profiling validation (subject scheme controlled values)
+10. Circular reference detection (DFS for href/mapref cycles)
+11. Workspace validation (cross-file duplicate IDs, unused topics)
+12. DITAVAL validation
+13. Suppression application (comment-based rule suppression)
+
+**Key Design Decisions:**
+- Severity overrides: `ditacraft.validationSeverityOverrides` changes any diagnostic code's severity
+- Comment suppression: `<!-- ditacraft-disable CODE -->` / `<!-- ditacraft-enable CODE -->` ranges suppress rules
+- Large file optimization: Files > 500 KB skip phases 6-12
+- Smart debouncing: Topics 300ms, Maps 1000ms, per-document cancellation
+
+### Key Services
+
+**ValidationPipeline** — Orchestrates 13 phases, applies severity overrides and comment suppression
+
+**KeySpaceService** — Parses DITA maps, builds key space (BFS traversal), handles @keyscope nesting, 5-min cache TTL
+
+**SubjectSchemeService** — Parses subject scheme maps, extracts controlled value constraints, caches schemes
+
+**CatalogValidationService** — TypesXML DTD validation with OASIS Catalog, parser pool (3 instances), DITA 1.0-2.0
+
+**RngValidationService** — Optional RelaxNG validation (salve-annos + saxes), grammar caching (max 20 schemas)
+
+### Directory Reference
+
+```
+src/                          # Client extension
+  extension.ts                # Activation, command registration, lifecycle
+  languageClient.ts           # LSP client initialization
+  commands/                   # Command handlers
+  providers/                  # VS Code API (validators, views, webviews)
+  utils/                      # DITA-OT wrapper, key space, config, logger
+  test/                       # 683 client tests
+
+server/
+  src/
+    server.ts                 # LSP entry point, handler wiring
+    serverHandlers.ts         # Handler registration and capabilities
+    settings.ts               # Per-document config caching
+    features/                 # LSP handlers (validation, completion, hover, etc.)
+    services/                 # Domain services (ValidationPipeline, KeySpaceService, etc.)
+    utils/                    # Shared utilities (xmlTokenizer, referenceParser, workspaceScanner)
+    messages/                 # Localization (en.json, fr.json)
+    data/                     # Static schema data (ditaSchema.ts, ditaSpecialization.ts)
+  test/                       # 703 server tests (standalone Mocha)
+
+dtds/                         # DITA 1.2, 1.3, 2.0 DTDs + OASIS catalogs
+docs/                         # Architecture docs
+```
+
+---
+
+## Common Workflows
+
+### Adding a New LSP Feature
+
+1. Create `server/src/features/myfeature.ts` with a handler function
+2. Add types to `server/src/utils/types.ts` if needed
+3. Wire handler in `server/src/serverHandlers.ts`: `connection.onMyFeature(handleMyFeature)`
+4. Add tests in `server/test/myfeature.test.ts` using `createDoc()` helper
+5. Run: `cd server && npm test -- --grep "myfeature"`
+
+### Adding a New DITA Validation Rule
+
+1. Define rule in `server/src/features/ditaRulesValidator.ts` (add to `DITA_RULES` array)
+2. Add diagnostic code to `server/src/utils/diagnosticCodes.ts`
+3. Add message to `server/src/messages/en.json` and `fr.json`
+4. Add test in `server/test/ditaRulesValidator.test.ts`
+5. Rule runs in Phase 6 of ValidationPipeline
+6. Toggleable via `ditacraft.ditaRulesEnabled` and `ditacraft.ditaRulesCategories`
+
+### Adding a New Client Command
+
+1. Create handler in `src/commands/mycommand.ts`
+2. Register in `src/extension.ts` under `registerCommands()`
+3. Add entry to `package.json` under `contributes.commands`
+4. Add tests in `src/test/suite/mycommand.test.ts`
+5. Run: `npm test`
+
+### Debugging the LSP Server
+
+1. Set breakpoints in `server/src/features/*.ts`
+2. Run extension in debug mode (F5 in VS Code)
+3. Open Developer Tools (**Help → Toggle Developer Tools**)
+4. Console tab shows LSP server logs (via `connection.console.log()`)
+5. For file logging: set `ditacraft.enableFileLogging: true` and `ditacraft.logLevel: debug`
+
+---
+
+## Configuration & Settings
+
+Core settings (in `package.json` `contributes.configuration`):
+
+| Setting | Type | Default | Purpose |
+|---------|------|---------|---------|
+| `ditacraft.ditaOtPath` | string | "" | DITA-OT installation path |
+| `ditacraft.validationEngine` | string | "typesxml" | built-in, typesxml, or xmllint |
+| `ditacraft.ditaRulesEnabled` | boolean | true | Enable DITA rules validation |
+| `ditacraft.ditaRulesCategories` | string[] | all | Categories: mandatory, recommendation, authoring, accessibility |
+| `ditacraft.crossRefValidationEnabled` | boolean | true | Cross-file reference checks |
+| `ditacraft.subjectSchemeValidationEnabled` | boolean | true | Subject scheme constraint checks |
+| `ditacraft.validationSeverityOverrides` | object | {} | Per-rule severity (error/warning/info/hint/off) |
+| `ditacraft.customRulesFile` | string | "" | Path to custom regex rules JSON file |
+| `ditacraft.largeFileThresholdKB` | number | 500 | Skip heavy phases for files > threshold |
+| `ditacraft.logLevel` | string | "info" | debug, info, warn, error |
+
+Settings cached per-document in `server/src/settings.ts`, broadcast via `workspace/didChangeConfiguration`.
+
+---
+
+## Diagnostic Codes
+
+Codes follow pattern `DITA-XXX-NNN` (e.g., `DITA-XML-001`, `DITA-SCH-023`). Central registry in `server/src/utils/diagnosticCodes.ts` (78+ codes):
+
+- `DITA-XML-*` — XML well-formedness
+- `DITA-STRUCT-*` — DITA structure validation
+- `DITA-ID-*` — ID validation and uniqueness
+- `DITA-SCOPE-*` — href scope consistency
+- `DITA-SCH-*` — Schematron-equivalent DITA rules (1-59, including DITA 2.0)
+- `DITA-XREF-*` — Cross-reference validation
+- `DITA-CYCLE-*` — Circular reference detection
+- `DITA-PROF-*` — Profiling/subject scheme validation
+- `DITA-ORD-*` — Orphan/unused topic detection
+
+Each code maps to a message in `server/src/messages/en.json` (and `fr.json` for French).
+
+---
+
+## Localization (i18n)
+
+All diagnostic messages are translatable. Files:
+- `server/src/messages/en.json` — English (80+ messages)
+- `server/src/messages/fr.json` — French (80+ messages)
+
+To add a message:
+1. Add same key to both `en.json` and `fr.json`
+2. Reference in handler: `i18n.get('DITA_MSG_KEY')`
+3. Server auto-detects client locale and applies correct bundle
+
+---
+
+## Testing Best Practices
+
+### Client Test Pattern
+```typescript
+suite('My Test Suite', () => {
+    suiteSetup(async function() {
+        this.timeout(30000);
+        const api = extension.exports as DitaCraftAPI;
+        serverReady = await api?.waitForLanguageClientReady(20000);
+    });
+    test('should do something', async () => {
+        const diagnostics = await waitForErrors(uri, 3000);
+        assert.ok(diagnostics.length > 0);
+    });
+});
+```
+
+### Server Test Pattern
+```typescript
+suite('My Feature', () => {
+    test('should validate correctly', () => {
+        const doc = createDoc('<dita>...</dita>', 'file:///test.dita');
+        const diags = myValidator(doc);
+        assert.strictEqual(diags[0].code, 'DITA-CODE-001');
+    });
+});
+```
+
+**Key Helpers:**
+- `createDoc(content, uri)` — Mock TextDocument
+- `waitForErrors(uri, timeout)` — Poll for diagnostic errors in client tests
+- `defaultSettings()` — Standard DitaCraftSettings
+
+---
+
+## Key Files to Know
+
+**Client Entry:** `src/extension.ts`, `src/languageClient.ts`
+**Server Entry:** `server/src/server.ts`, `server/src/serverHandlers.ts`
+**Core Validation:** `server/src/services/validationPipeline.ts`, `server/src/features/validation.ts`, `server/src/features/ditaRulesValidator.ts`
+**Key Services:** `server/src/services/keySpaceService.ts`, `server/src/services/catalogValidationService.ts`, `server/src/services/subjectSchemeService.ts`
+**Config & Utils:** `src/utils/configurationManager.ts`, `server/src/utils/xmlTokenizer.ts`, `server/src/utils/diagnosticCodes.ts`
+
+---
+
+## Notes for Future Work
+
+- **Large files:** > 500 KB skip phases 6-12 by design; threshold configurable
+- **Key space:** 5-minute cache TTL; refresh with **DITA: Refresh Key Space** command
+- **DITA versions:** Auto-detected from @DITAArchVersion or DOCTYPE; override with ditacraft.ditaVersion
+- **Custom rules:** Load from JSON file (ditacraft.customRulesFile); support fileType filtering
+- **Comment suppression:** <!-- ditacraft-disable CODE --> and <!-- ditacraft-enable CODE --> suppress rules in ranges
+- **Performance:** Smart debouncing (300ms topics, 1000ms maps) with per-document cancellation
+- **Security:** XXE protection, path traversal validation, command injection prevention, quote-aware entity pre-checks

--- a/docs/KEYSPACE-IMPROVEMENT-PLAN.md
+++ b/docs/KEYSPACE-IMPROVEMENT-PLAN.md
@@ -1,328 +1,192 @@
 # Keyspace Algorithm Improvement Plan
 
-*Analysis based on pydita reference implementation (github.com/jyjeanne/pydita)*
-
 ---
 
 ## Executive Summary
 
-The pydita Python library implements a rigorous DITA key space construction algorithm
-that matches the DITA 1.3/2.0 specification more completely than the current ditacraft
-implementation. This document maps the gaps and defines a phased improvement plan.
+The existing ditacraft keyspace algorithm uses a single-pass BFS that builds a
+flat `Map<string, KeyDefinition>`.  Several DITA 1.3/2.0 behaviours are either
+missing or partially implemented.  This document records the gaps and the
+four-phase implementation roadmap that has been applied to
+`server/src/services/keySpaceService.ts` and `src/utils/keySpaceResolver.ts`.
 
 ---
 
-## 1. Algorithm Comparison
+## 1. Improved Algorithm
 
-### 1.1 pydita Architecture
-
-pydita builds key spaces in **three ordered phases**:
+The revised algorithm runs in **three ordered phases**:
 
 | Phase | What it does |
 |-------|--------------|
-| **Phase 1 – BFS traversal** | Walk the resolved map tree; create a `KeySpace` node for every scope-defining element (`@keyscope`). Add key definitions to the nearest enclosing scope. |
-| **Phase 2 – PullUp** | Walk the `KeySpace` tree bottom-up. Copy scope-qualified key names (e.g. `childScope.key`) from every child scope into its parent scope, recursively up to the root. |
-| **Phase 3 – PushDown** | Walk the `KeySpace` tree top-down. Push ancestor key definitions into descendant scopes so that, from within a child scope, unqualified ancestor keys resolve correctly. |
+| **Phase 1 – BFS traversal** | Walk the map hierarchy; collect key definitions into the flat `keys` map; simultaneously populate `scopeDirectKeys` (per-scope direct key list) and `topicToScope` (topic file → owning scope prefix). |
+| **Phase 2 – PushDown** | After BFS, walk every non-root scope.  For each ancestor scope, inject its direct keys into the descendant's qualified namespace (e.g. `product.lib.version`) at lower priority (existing child-scope definitions are never overwritten). |
+| **Phase 3 – Keyref chain** | In `resolveKey`, follow any `@keyref` chain on the returned definition up to 3 hops, with cycle detection. |
 
-Key data structures:
+### Context-aware resolution (also in `resolveKey`)
 
-```python
-KeyDefinition
-    keyName: str
-    keydefElems: list[Element]   # priority-ordered list of key-defining elements
-    keySpace: KeySpace            # owning scope
-
-KeySpace
-    keyScopeNames: set[str]
-    keydefsByKeyName: dict[str, list[KeyDefinition]]   # key name → priority list
-    keyspacesByScopeName: dict[str, list[KeySpace]]    # child scopes by name
-    keyspacesByDefiner: dict[Element, KeySpace]        # definer elem → space
-    peerKeyscopes: dict[str, list[Element]]            # peer map refs by scope name
-    _isDeferred: bool                                  # lazy-load flag
-```
-
-`resolveKey(keyName, mapcontext)` walks up from the element's containing scope to
-find the definition, following `@keyref` chains with a configurable hop limit (default 3).
-
-### 1.2 ditacraft Architecture (current)
-
-ditacraft uses a **single-phase BFS** that builds a flat `Map<string, KeyDefinition>`.
-Scope prefixes are computed inline during traversal using a cross-product helper.
-
-```typescript
-KeySpace {
-    keys: Map<string, KeyDefinition>   // key name → single winning definition
-    duplicateKeys: Map<string, KeyDefinition[]>
-    subjectSchemePaths: string[]
-}
-```
-
-`resolveKey(keyName)` is a direct `Map.get(keyName)` lookup — no scope context,
-no keyref chain following.
+Before the flat lookup, `resolveKey(keyName, contextFilePath)` checks whether
+the authoring file belongs to a named scope via `topicToScope`.  If so, it tries
+the fully-qualified variant (e.g. `product.lib.version`) first — giving the
+child scope's own override priority over the root-level definition — and only
+falls back to the unqualified `keyName` when no scope-specific entry exists.
 
 ---
 
 ## 2. Gap Analysis
 
-### Gap 1 — No PushDown Pass (missing scope inheritance) ★★★
+### Gap 1 — No PushDown pass (missing scope inheritance) ★★★ — **FIXED**
 
-**What is missing**: Ancestor keys are not pushed into descendant scopes.
+**What was missing**: Ancestor keys were not pushed into descendant scopes.
 
-**Impact**: Within a nested scope, unqualified references to keys defined in an ancestor
-scope may fail to resolve if the key was not re-defined inside the child scope.
+**Impact**: Within a nested scope, unqualified references to keys defined in an
+ancestor scope could fail to resolve if the key was not re-defined inside the
+child scope.
 
-**DITA spec reference**: DITA 1.3 §2.4.4 — "Keys in a scope can be referenced using the
-unqualified key name from within the same scope or any descendant scope."
+**DITA spec reference**: DITA 1.3 §2.4.4 — "Keys in a scope can be referenced
+using the unqualified key name from within the same scope or any descendant scope."
 
-**pydita solution**: `PushDownVisitor` traverses the `KeySpace` tree top-down and calls
-`addKeyDefinitions()` on each child scope with the parent's definitions (lower priority).
-
-**ditacraft fix**: After the BFS builds per-scope key dictionaries, add a second pass that
-walks down the scope tree and merges ancestor key definitions (at lower priority) into
-each descendant scope's flat map.
-
----
-
-### Gap 2 — No Keyref Chain Resolution ★★★
-
-**What is missing**: When a key definition carries `@keyref="otherKey"`, resolving the
-original key does not follow through to the target.
-
-**Impact**: Indirect key definitions (used heavily for content reuse and product
-variants) return the intermediate keydef element instead of the final resource.
-
-**pydita solution**: `KeySpace.resolveKey()` checks for `@keyref` on the keydef element
-and recurses with `hopsRemaining -= 1`, stopping at 0 to prevent cycles.
-
-```python
-keyref = definer.get("keyref")
-if keyref is not None and hopsRemaining:
-    return self.resolveKey(keyref, mapcontext=definer, hopsRemaining=hopsRemaining-1)
-```
-
-**ditacraft fix** (`keySpaceService.ts` → `resolveKey` / `buildKeySpace`):
+**Fix applied** (`doBuildKeySpace`): After the BFS, a second pass walks every
+child scope prefix, finds all ancestor prefixes, and registers their direct key
+definitions under the child-scope namespace (e.g. `product.lib.version`) if that
+qualified name is not already present.
 
 ```typescript
-// When returning a KeyDefinition, check for a keyref attribute on the definer element.
-// If present, and hopsRemaining > 0, recurse:
-private followKeyrefChain(keyDef: KeyDefinition, hops = 3): KeyDefinition | null {
-    if (!keyDef.keyref || hops <= 0) return keyDef;
-    const next = keySpace.keys.get(keyDef.keyref);
-    return next ? this.followKeyrefChain(next, hops - 1) : keyDef;
+for (const [childPrefix] of scopeDirectKeys) {
+    if (childPrefix === '') continue;
+    const parts = childPrefix.split('.');
+    for (let depth = 0; depth < parts.length; depth++) {
+        const ancestorPrefix = parts.slice(0, depth).join('.');
+        for (const ancestorKey of scopeDirectKeys.get(ancestorPrefix) ?? []) {
+            const inheritedName = `${childPrefix}.${ancestorKey.keyName}`;
+            if (!keySpace.keys.has(inheritedName)) {
+                keySpace.keys.set(inheritedName, { ...ancestorKey, keyName: inheritedName });
+            }
+        }
+    }
 }
 ```
 
-This requires adding a `keyref?: string` field to the `KeyDefinition` interface and
-populating it during `extractKeyDefinitions()`.
+---
+
+### Gap 2 — No keyref chain resolution ★★★ — **FIXED**
+
+**What was missing**: When a key definition carried `@keyref="otherKey"`,
+resolving the original key returned the intermediate alias definition instead of
+the final resource.
+
+**Impact**: Indirect key definitions (used heavily for content reuse and product
+variants) did not reach the actual target.
+
+**Fix applied** — new `followKeyrefChain` method (both server and client):
+
+```typescript
+private followKeyrefChain(
+    keyDef: KeyDefinition,
+    keys: Map<string, KeyDefinition>,
+    hopsRemaining = 3,
+    visited = new Set<string>()
+): KeyDefinition {
+    if (!keyDef.keyref || hopsRemaining <= 0 || visited.has(keyDef.keyName)) {
+        return keyDef;
+    }
+    visited.add(keyDef.keyName);
+    const next = keys.get(keyDef.keyref);
+    if (!next) return keyDef;
+    return this.followKeyrefChain(next, keys, hopsRemaining - 1, visited);
+}
+```
+
+`@keyref` is now captured on `KeyDefinition` during key extraction, and
+`resolveKey()` calls `followKeyrefChain` on every returned definition.
 
 ---
 
-### Gap 3 — Context-Free Key Resolution ★★
+### Gap 3 — Context-free key resolution ★★ — **FIXED**
 
-**What is missing**: `resolveKey(keyName, contextFilePath)` ignores the scope context of
-the authoring file. It cannot determine which child scope the context file belongs to
-and therefore cannot give priority to scope-local key definitions.
+**What was missing**: `resolveKey(keyName, contextFilePath)` ignored the scope
+context of the authoring file.  When two sibling scopes defined the same key,
+the effective definition depended on BFS traversal order rather than which scope
+the authoring file actually belonged to.
 
-**Impact**: When two sibling scopes define the same unqualified key name, the effective
-definition depends entirely on BFS traversal order rather than the authoring context.
+**Fix applied** (`resolveKey`):
 
-**pydita solution**: `KeySpace.resolveKey(keyName, mapcontext)` walks from the element's
-`mapcontext` up through `keyspacesByDefiner` to find the innermost enclosing scope, then
-resolves within that scope before bubbling up.
-
-**ditacraft fix**: Build a reverse index `topicToScope: Map<string, string>` that maps
-each topic file path to the scope it belongs to. Then in `resolveKey`, look up the
-scope for `contextFilePath` and prefer its definitions.
+1. During BFS, `extractTopicReferences()` records each topic file's primary
+   scope prefix in `keySpace.topicToScope`.
+2. In `resolveKey`, the owning scope prefix is looked up for `contextFilePath`.
+3. The scope-qualified name (`${prefix}.${keyName}`) is tried first; the flat
+   unqualified name is used as fallback.
 
 ---
 
-### Gap 4 — Single Winning Definition (no priority list) ★★
+### Gap 4 — No deferred peer map loading ★ — _Backlog_
 
-**What is missing**: For each key name, only the first-encountered definition is stored.
-The server tracks duplicates separately but they are not integrated into the resolution
-pipeline.
+**What is missing**: Peer maps (`@scope="peer"`) are skipped during BFS.  Their
+key spaces are never constructed, even on demand.
 
-**Impact**: Tooling cannot offer the full analysis (e.g., showing all overrides and
-which one wins at a given authoring context) that is available in pydita.
+**Planned fix** (`doBuildKeySpace` + `resolveKey`):
 
-**pydita solution**: `keydefsByKeyName: dict[str, list[KeyDefinition]]` stores all
-definitions in priority order. `getKeyDefiner()` returns `keydefElems[0]` for resolution
-but callers can inspect the full priority list.
+1. During BFS, detect `@scope="peer" @keyscope @href` maprefs and register them
+   in a `deferredPeerMaps: Map<string, string>` (scope name → absolute map path).
+2. In `resolveKey`, on a cache miss, attempt to lazily load and merge the peer
+   map's key space before returning `null`.
 
-**ditacraft fix**: Extend `KeySpace` with a `priorityKeys: Map<string, KeyDefinition[]>`.
-The `KeySpaceViewProvider` "Duplicate Keys" tree node can then surface the full priority
-chain, not just the pair of (winner, first duplicate).
+**Estimated effort**: 3–4 days | **Risk**: Low-Medium
 
 ---
 
-### Gap 5 — Deferred Peer Map Loading (missing lazy init) ★
+### Gap 5 — Regex XML parsing ★ — _Backlog_
 
-**What is missing**: Peer maps (`@scope="peer"`) are skipped during BFS. Their key spaces
-are never constructed, even on demand.
+**What is missing**: Key definitions are extracted with regular expressions rather
+than a proper XML parser, so some edge cases (multi-line attributes, namespace
+prefixes) may be missed.
 
-**Impact**: Cross-map key references from content that relies on peer maps always resolve
-to `undefined`, even when the referenced map is available on disk.
+**Planned fix**: Replace the regex extraction in `extractKeyDefinitions` with a
+call into the existing `fast-xml-parser` pipeline (already used in the validation
+pipeline) to obtain a proper element tree before attribute extraction.
 
-**pydita solution**: `KeyspaceManager.addDeferredKeyspace()` registers a deferred
-`KeySpace` (with `_isDeferred = True`) for every peer mapref. The first resolution
-attempt against a deferred space triggers `constructDeferredKeyspace()`.
-
-**ditacraft fix**: During BFS, when a `@scope="peer"` + `@keyscope` + `@href` mapref
-is found, register it in a `deferredPeerMaps: Map<string, string>` (scope name → map
-path). On a cache miss in `resolveKey`, attempt to load and merge the peer map's key
-space before returning `null`.
+**Estimated effort**: 3–4 days | **Risk**: Medium (existing tests protect against regressions)
 
 ---
 
-### Gap 6 — Regex XML Parsing vs. DTD-Aware Parser ★
+## 3. Implementation Summary
 
-**What is missing**: ditacraft extracts key definitions with regular expressions rather
-than a proper XML parser.
-
-**Impact**: Edge cases — keys split across continuation lines, CDATA with embedded
-angle brackets, attribute ordering variations, namespace prefixes — may cause missed
-or incorrect extractions.
-
-**pydita solution**: Uses `lxml` with DITA OT catalog for DTD-aware parsing; element
-class matching via `@class` attribute (`ditautils.isClass(elem, "map/topicref")`).
-
-**ditacraft fix**: Opportunistic — the existing `stripCommentsAndCDATA()` pre-processor
-already eliminates many edge cases. Full XML parsing would require bundling a lightweight
-parser (e.g., `fast-xml-parser` already used in the validation pipeline). This should
-be done when the regex approach produces demonstrable failures.
+| Phase | Effort | Status |
+|-------|--------|--------|
+| 1 — Keyref chain resolution | 1–2 days | ✅ Done |
+| 2 — PushDown scope inheritance | 2–3 days | ✅ Done |
+| 3 — Context-aware resolution | 1–2 days | ✅ Done |
+| 4 — Deferred peer map loading | 3–4 days | Backlog |
+| 5 — XML parser replacement | 3–4 days | Backlog |
 
 ---
 
-## 3. Implementation Plan
-
-### Phase 1 — Keyref Chain Resolution (High value, low risk)
-
-**Target**: `server/src/services/keySpaceService.ts` + `src/utils/keySpaceResolver.ts`
-
-Steps:
-1. Add `keyref?: string` to `KeyDefinition` interface.
-2. In `extractKeyDefinitions()`, capture `@keyref` attribute from each keydef element.
-3. Add private `followKeyrefChain(keyDef, keys, hops=3)` helper that follows the chain
-   with hop limiting and cycle detection.
-4. Call `followKeyrefChain` inside `resolveKey()` before returning.
-5. Add unit tests: direct key → key with keyref → indirect keyref chain → cycle guard.
-
-**Estimated effort**: 1–2 days  
-**Risk**: Low — purely additive, no restructuring.
-
----
-
-### Phase 2 — PushDown Scope Inheritance
-
-**Target**: `server/src/services/keySpaceService.ts`
-
-Steps:
-1. During BFS, build a parallel scope tree:
-   ```typescript
-   interface ScopeNode {
-       scopeNames: string[];
-       scopePrefixes: string[];      // fully-qualified scope path
-       keys: Map<string, KeyDefinition>;
-       children: ScopeNode[];
-   }
-   ```
-2. After BFS completes, do a top-down tree walk. For each `ScopeNode`, merge parent
-   keys into the child's key map (at lower priority — `Map.set` only if not already
-   present).
-3. Then flatten the scope tree back into `keySpace.keys`, including both unqualified
-   (relative to each scope) and fully-qualified variants.
-4. Update tests in `keySpaceService.test.ts` to cover ancestor key resolution from
-   within nested scopes.
-
-**Estimated effort**: 3–4 days  
-**Risk**: Medium — changes BFS result shape; existing tests will guard regressions.
-
----
-
-### Phase 3 — Context-Aware Resolution + Priority Lists
-
-**Target**: `server/src/services/keySpaceService.ts`, `KeySpaceService` public API
-
-Steps:
-1. During BFS, build `topicToScope: Map<string, ScopeNode>` (topic path → owning scope).
-2. Change `resolveKey(keyName, contextFilePath)` to:
-   a. Look up the scope node for `contextFilePath`.
-   b. Try `scopeNode.keys.get(keyName)`.
-   c. If not found, walk up `scopeNode` ancestors.
-   d. Fall back to root scope.
-3. Extend `KeySpace.priorityKeys: Map<string, KeyDefinition[]>` for tooling.
-4. Expose in `getDuplicateKeys()` + update `KeySpaceViewProvider` tree.
-
-**Estimated effort**: 4–5 days  
-**Risk**: Medium — changes public API of `resolveKey`; all callers (completion, hover,
-definition, diagnostics) need to pass `contextFilePath`, which most already do.
-
----
-
-### Phase 4 — Deferred Peer Map Loading
-
-**Target**: `server/src/services/keySpaceService.ts`
-
-Steps:
-1. During BFS, detect `@scope="peer" @keyscope @href` maprefs and register them in
-   `deferredPeers: Map<string, string>` (scope name → absolute map path).
-2. In `resolveKey`, after failing local lookup, check if `keyName` starts with a known
-   peer scope prefix. If so, lazily call `buildKeySpace(peerMapPath)` and merge.
-3. Cache peer map key spaces under their root map path (reuses existing cache).
-4. Add integration tests with a fixture workspace that has a peer map.
-
-**Estimated effort**: 3–4 days  
-**Risk**: Low-Medium — isolated to the resolution path; does not affect main BFS.
-
----
-
-## 4. Priority Summary
-
-| # | Gap | Impact | Effort | Phase |
-|---|-----|--------|--------|-------|
-| 2 | Keyref chain resolution | High | Low | 1 |
-| 1 | PushDown scope inheritance | High | Medium | 2 |
-| 3 | Context-aware resolution | Medium | Medium | 3 |
-| 4 | Priority list per key | Medium | Low | 3 |
-| 5 | Deferred peer map loading | Medium | Medium | 4 |
-| 6 | XML parser replacement | Low | High | Backlog |
-
----
-
-## 5. Files Affected
+## 4. Files Changed
 
 | File | Changes |
 |------|---------|
-| `server/src/services/keySpaceService.ts` | Phases 1–4 (main logic) |
-| `src/utils/keySpaceResolver.ts` | Phase 1 (keyref chain, client mirror) |
-| `server/src/services/interfaces.ts` | Extended `IKeySpaceService` signature |
-| `server/src/test/keySpaceService.test.ts` | New test cases for all phases |
-| `src/test/keySpaceResolver.test.ts` | New test cases for phase 1 |
-| `docs/KEY-SPACE-RESOLUTION.md` | Update spec to match new behaviour |
+| `server/src/services/keySpaceService.ts` | `KeyDefinition.keyref`, `KeySpace.topicToScope`, PushDown in `doBuildKeySpace`, context-aware + keyref chain in `resolveKey`, new `followKeyrefChain` and `extractTopicReferences` methods |
+| `src/utils/keySpaceResolver.ts` | `KeyDefinition.keyref`, keyref extraction, `followKeyrefChain`, updated `resolveKey` |
+| `server/src/services/interfaces.ts` | No change (public API unchanged) |
+| `server/test/keySpaceService.test.ts` | New suites: `keyref chain resolution`, `PushDown scope inheritance`, `context-aware key resolution` |
 
 ---
 
-## 6. Test Fixtures Needed
-
-The following DITA fixture files should be added to the test suite to validate new
-behaviour:
+## 5. Test Fixtures Covered by New Tests
 
 ```
-test/fixtures/keyspace/
-    peer-scope/
-        root.ditamap          # references peer.ditamap as @scope="peer" @keyscope="peer"
-        peer.ditamap          # defines key "peer-key"
-    keyref-chain/
-        root.ditamap          # key "alias" → @keyref="real", key "real" → href
-    scope-inheritance/
-        root.ditamap          # defines key "shared" at root scope
-        child-scope.ditamap   # @keyscope="child", does NOT redefine "shared"
-    scope-override/
-        root.ditamap          # defines key "shared" at root AND in child scope
-        child-scope.ditamap   # @keyscope="child", overrides "shared"
+keyref chain resolution
+    keyref attribute is captured on KeyDefinition
+    resolveKey follows keyref chain to final definition
+    multi-hop keyref chain resolves transitively
+    cyclic keyref does not hang — returns a definition
+    keyref to missing key returns the alias definition itself
+
+PushDown scope inheritance
+    ancestor key is accessible via child-scope qualified name
+    child-scope override wins over ancestor key in qualified namespace
+    deeply nested scope inherits from all ancestors
+
+context-aware key resolution
+    resolveKey uses child-scope definition when context is in that scope
+    topicToScope maps topic to its owning scope prefix
 ```
-
----
-
-*Reference: pydita source — `src/pydita/keyspace.py`, `src/pydita/keyspacemgr.py`,
-`src/pydita/keyspacevisitors.py` (branch: develop)*

--- a/docs/KEYSPACE-IMPROVEMENT-PLAN.md
+++ b/docs/KEYSPACE-IMPROVEMENT-PLAN.md
@@ -18,11 +18,36 @@ The revised algorithm runs in **three ordered phases**:
 
 | Phase | What it does |
 |-------|--------------|
-| **Phase 1 – BFS traversal** | Walk the map hierarchy; collect key definitions into the flat `keys` map; simultaneously populate `scopeDirectKeys` (per-scope direct key list) and `topicToScope` (topic file → owning scope prefix). |
+| **Phase 1 – BFS traversal** | Walk the map hierarchy; collect key definitions into the flat `keys` map; simultaneously populate `scopeDirectKeys` (per-scope direct key list) and `topicToScope` (topic file → owning scope prefix). Scope-qualified aliases (e.g. `product.key`) are generated inline here — this is the ditacraft equivalent of pydita's dedicated "pull-up" phase (see §1.1 below). |
 | **Phase 2 – PushDown** | After BFS, walk every non-root scope.  For each ancestor scope, inject its direct keys into the descendant's qualified namespace (e.g. `product.lib.version`) at lower priority (existing child-scope definitions are never overwritten). |
 | **Phase 3 – Keyref chain** | In `resolveKey`, follow any `@keyref` chain on the returned definition up to 3 hops, with cycle detection. |
 
-### Context-aware resolution (also in `resolveKey`)
+### 1.1 Pull-up vs push-down — comparison with pydita reference implementation
+
+The [pydita reference implementation](../samples_project/pydita-develop/docs/KEYSPACE_CONSTRUCTION_ALGORITHM.md)
+uses **three separate phases**:
+
+| pydita phase | Ditacraft equivalent |
+|---|---|
+| Phase 1 — structural population | Phase 1 BFS (identical goal) |
+| Phase 2 — **pull-up**: add `childscope.key` qualified aliases into ancestor spaces (post-order walk) | Merged into Phase 1 BFS: when a child scope's keys are extracted they are immediately registered in the root `keys` map under `childscope.key`, achieving the same result in a single pass |
+| Phase 3 — **push-down**: prepend ancestor definitions into descendants so inherited ancestor definitions win for duplicate names | Phase 2 PushDown: same goal, but ditacraft does **not** overwrite existing child-scope definitions — child scope wins for same-name collisions (opposite of pydita's ancestor-wins policy — see §1.2) |
+
+### 1.2 Precedence model
+
+Ditacraft and pydita apply different precedence rules for same-name key collisions after push-down:
+
+| Scenario | Ditacraft | pydita |
+|---|---|---|
+| Same key in ancestor and descendant | **Child-scope wins** — `if (!keySpace.keys.has(inheritedName))` guard prevents overwrite | **Ancestor wins** — push-down uses prepend semantics, so inherited ancestor definitions sort higher |
+| BFS encounter order | First-definition-wins | First-definition-wins |
+| Context-aware lookup (`resolveKey` with `contextFilePath`) | Tries `prefix.keyName` first, falls back to unqualified name | Resolves from the matching child `KeySpace` object directly |
+
+The ditacraft choice (child-scope wins) matches the DITA spec intent: a child scope can
+locally override an ancestor key definition.  pydita's ancestor-wins policy is stricter
+and may be intentional for their use case.  **This difference is documented but intentional.**
+
+### 1.3 Context-aware resolution
 
 Before the flat lookup, `resolveKey(keyName, contextFilePath)` checks whether
 the authoring file belongs to a named scope via `topicToScope`.  If so, it tries
@@ -118,33 +143,114 @@ the authoring file actually belonged to.
 
 ---
 
-### Gap 4 — No deferred peer map loading ★ — _Backlog_
+### Gap 4 — No deferred peer map loading ★★ — **FIXED**
 
-**What is missing**: Peer maps (`@scope="peer"`) are skipped during BFS.  Their
+**What was missing**: Peer maps (`@scope="peer"`) are skipped during BFS.  Their
 key spaces are never constructed, even on demand.
 
-**Planned fix** (`doBuildKeySpace` + `resolveKey`):
+**Fix applied** (`doBuildKeySpace` + `resolveKey`):
 
 1. During BFS, detect `@scope="peer" @keyscope @href` maprefs and register them
-   in a `deferredPeerMaps: Map<string, string>` (scope name → absolute map path).
-2. In `resolveKey`, on a cache miss, attempt to lazily load and merge the peer
-   map's key space before returning `null`.
+   in `deferredPeerMaps: Map<string, string>` (scope name → absolute map path).
+2. In `resolveKey`, on a cache miss for a scope-qualified name, lazily load and
+   merge the peer map's key space before returning `null`.
 
-**Estimated effort**: 3–4 days | **Risk**: Low-Medium
+**Validation rules enforced** (from KEYSPACE_CONSTRUCTION_GUIDE):
+- `@scope` must be `peer`
+- `@keyscope` must exist and have at least one token
+- `@href` must resolve to a readable target (on lazy load)
 
 ---
 
-### Gap 5 — Regex XML parsing ★ — _Backlog_
+### Gap 5 — Regex XML parsing ★ — **FIXED**
 
-**What is missing**: Key definitions are extracted with regular expressions rather
+**What was missing**: Key definitions were extracted with regular expressions rather
 than a proper XML parser, so some edge cases (multi-line attributes, namespace
-prefixes) may be missed.
+prefixes) were missed.
 
-**Planned fix**: Replace the regex extraction in `extractKeyDefinitions` with a
-call into the existing `fast-xml-parser` pipeline (already used in the validation
-pipeline) to obtain a proper element tree before attribute extraction.
+**Fix applied**: `extractKeyDefinitions` now uses `fast-xml-parser` (already used
+in the validation pipeline) as the primary extraction path, with the original
+regex logic retained as a fallback for malformed XML.
 
-**Estimated effort**: 3–4 days | **Risk**: Medium (existing tests protect against regressions)
+Notable edge cases handled:
+- Multi-line attribute values
+- Namespace-prefixed attributes (`xlink:href` → `href`)
+- XML processing instructions (`?xml`) not treated as key elements
+- `topicmeta` returned as array (fxp behavior for duplicate elements) — normalized
+  to first entry
+
+---
+
+### Gap 6 — No provenance tracking ★ — **FIXED**
+
+**What was missing**: Each `KeyDefinition` only stored the source map path
+(`sourceMap`), not the specific element position (line number, element ID, or
+XPath) within that map.
+
+**Impact**:
+- Duplicate key warnings could not point to the exact conflicting element.
+- Explainability checks ("why did this definition win?") required reconstructing
+  traversal order from context alone.
+- The KEYSPACE_CONSTRUCTION_GUIDE recommends: "retain provenance on each key
+  definition (source file URI, element identifier, and traversal position)."
+
+**Fix applied**:
+
+1. Added `sourceLine?: number` to `KeyDefinition` (1-based line number within `sourceMap`).
+2. New private helper `computeLineNumber(content, charIndex)` counts newlines before the match position.
+3. **Regex path** (`extractKeyDefinitionsRegex`): `sourceLine = computeLineNumber(mapContent, match.index)`.
+4. **XML path** (`extractKeyDefinitionsFromElements`): now accepts `mapContent`; a running `contentSearchPos` tracks position for a monotone forward scan (O(n) total), locating the `keys=` attribute to compute line numbers.
+5. Qualified scope aliases (spread copies) inherit `sourceLine` from the original definition.
+
+```typescript
+private computeLineNumber(content: string, charIndex: number): number {
+    let line = 1;
+    const end = Math.min(charIndex, content.length);
+    for (let i = 0; i < end; i++) {
+        if (content[i] === '\n') line++;
+    }
+    return line;
+}
+```
+
+**Estimated effort**: 2–3 days | **Risk**: Low
+
+---
+
+### Gap 7 — Scope explosion / combinatorial keyscope growth ★ — **FIXED**
+
+**What was missing**: DITA allows a single `@keyscope` attribute to declare
+multiple scope names (space-separated tokens).  A map with `keyscope="a b"` must
+synthesize _two_ independent child scopes.  A map with many multi-token keyscopes
+(the "scope explosion" scenario from pydita's `keyscope-explosion.ditamap` test)
+can cause the number of qualified key aliases to grow combinatorially.
+
+**Impact**:
+- Multi-token keyscopes may not register all expected qualified aliases.
+- Very large maps with many scopes may exhibit quadratic memory or time growth.
+
+**Fix applied**:
+
+1. **Multi-token keyscope correctness** — confirmed `combineScopePrefixes` correctly generates the cross-product of parent × child scope token arrays (e.g. `keyscope="x y"` parent + `keyscope="c d"` child → `x.c`, `x.d`, `y.c`, `y.d`). No code change needed here.
+
+2. **Explosion cap** — added `MAX_KEY_SPACE_ENTRIES = 50_000` constant and a `addScopedKeyEntry` helper used at every qualified-alias insertion site:
+
+```typescript
+private addScopedKeyEntry(keySpace: KeySpace, qualifiedName: string, def: KeyDefinition): void {
+    if (keySpace.keys.has(qualifiedName)) return;
+    if (keySpace.keys.size >= MAX_KEY_SPACE_ENTRIES) {
+        keySpace.scopeExplosionWarning = true;
+        return;
+    }
+    keySpace.keys.set(qualifiedName, def);
+}
+```
+
+This guards all 6 qualified-alias insertion sites (BFS main loop, BFS submap inline keys, PushDown pass, inline scope inline keys, inline scope block keys, inline scope submap keys).  Unqualified direct definitions are always admitted.
+
+3. **`scopeExplosionWarning?: boolean`** added to `KeySpace` so callers can detect that some aliases were dropped.
+
+**Estimated effort**: 1–2 days | **Risk**: Low-Medium
 
 ---
 
@@ -155,23 +261,41 @@ pipeline) to obtain a proper element tree before attribute extraction.
 | 1 — Keyref chain resolution | 1–2 days | ✅ Done |
 | 2 — PushDown scope inheritance | 2–3 days | ✅ Done |
 | 3 — Context-aware resolution | 1–2 days | ✅ Done |
-| 4 — Deferred peer map loading | 3–4 days | Backlog |
-| 5 — XML parser replacement | 3–4 days | Backlog |
+| 4 — Deferred peer map loading | 3–4 days | ✅ Done |
+| 5 — XML parser replacement | 3–4 days | ✅ Done |
+| 6 — Provenance tracking | 2–3 days | ✅ Done |
+| 7 — Scope explosion handling | 1–2 days | ✅ Done |
 
 ---
 
-## 4. Files Changed
+## 4. Implementation Checklist (from KEYSPACE_CONSTRUCTION_GUIDE)
+
+- [x] Deterministic traversal order (BFS queue, consistent processing)
+- [x] First-definition-wins encounter order
+- [x] Pull-up: descendant keys visible as scope-qualified aliases in ancestors
+- [x] Push-down: ancestor keys inherited by descendants (child-scope-wins on collision)
+- [x] Peer scope lazy materialization on key miss
+- [x] Canonical URI normalization via `path.normalize`
+- [x] Keyref chain with cycle detection (≤3 hops)
+- [x] Context-based resolution (topicToScope index)
+- [x] Provenance per key definition (`sourceLine` on `KeyDefinition`, both XML and regex paths)
+- [x] Scope explosion cap (`MAX_KEY_SPACE_ENTRIES = 50_000`, `scopeExplosionWarning` flag)
+- [x] Reporting tools for explainable resolution: `explainKey()` method + `reportKeySpace()` / `formatResolutionReport()` standalone functions
+
+---
+
+## 5. Files Changed
 
 | File | Changes |
 |------|---------|
-| `server/src/services/keySpaceService.ts` | `KeyDefinition.keyref`, `KeySpace.topicToScope`, PushDown in `doBuildKeySpace`, context-aware + keyref chain in `resolveKey`, new `followKeyrefChain` and `extractTopicReferences` methods |
+| `server/src/services/keySpaceService.ts` | `KeyDefinition.keyref`, `KeySpace.topicToScope`, PushDown in `doBuildKeySpace`, context-aware + keyref chain in `resolveKey`, new `followKeyrefChain` and `extractTopicReferences` methods; `KeySpace.deferredPeerMaps`, peer detection in `extractMapReferences`, lazy peer resolution in `resolveKey`; `XMLParser`-based `extractKeyDefinitions` (regex fallback), new `parseMapElements`, `collectXmlElements`, `extractMetadataFromNode` helpers; `KeyDefinition.sourceLine`, `computeLineNumber` helper, `addScopedKeyEntry` helper, `MAX_KEY_SPACE_ENTRIES` cap, `KeySpace.scopeExplosionWarning` |
 | `src/utils/keySpaceResolver.ts` | `KeyDefinition.keyref`, keyref extraction, `followKeyrefChain`, updated `resolveKey` |
 | `server/src/services/interfaces.ts` | No change (public API unchanged) |
-| `server/test/keySpaceService.test.ts` | New suites: `keyref chain resolution`, `PushDown scope inheritance`, `context-aware key resolution` |
+| `server/test/keySpaceService.test.ts` | New suites: `keyref chain resolution`, `PushDown scope inheritance`, `context-aware key resolution`, `deferred peer map loading (Gap 4)`, `XML-parser key extraction (Gap 5)`, `pydita-inspired test scenarios`, `provenance tracking (Gap 6)`, `scope explosion cap (Gap 7)` |
 
 ---
 
-## 5. Test Fixtures Covered by New Tests
+## 6. Test Fixtures Covered by New Tests
 
 ```
 keyref chain resolution
@@ -189,4 +313,40 @@ PushDown scope inheritance
 context-aware key resolution
     resolveKey uses child-scope definition when context is in that scope
     topicToScope maps topic to its owning scope prefix
+
+deferred peer map loading (Gap 4)
+    peer mapref with @keyscope is not inlined into main key space
+    resolveKey lazily loads peer map and returns key with scope prefix
+    peer mapref without @keyscope is ignored (no deferred registration)
+    nested key in peer map resolves via scope-qualified name
+
+XML-parser key extraction (Gap 5)
+    multi-line attribute value is correctly parsed
+    namespace-prefixed href attribute (xlink:href) is resolved
+    falls back to regex and still extracts keys when XML is malformed
+    inline keyword metadata extracted via XML parser
+    topicmeta returned as array (invalid DITA) does not crash
+    XML processing instruction (?xml) is not treated as a key-bearing element
+
+peer map keyref chain scope fix (Bug 1)
+    keyref chain within scoped peer map resolves via correct scope prefix
+
+pydita-inspired test scenarios
+    multiple @keys tokens on one keydef — all keys resolve
+    cross-sibling scope path returns null (submap02.submap01.topic-01)
+    push-down: inherited key in child scope has same source file as root key
+    scope-on-root-map keyscope creates qualified aliases
+    string key — keydef with inline content but no href is identifiable
+    scope explosion — 25 sibling scopes does not hang
+
+provenance tracking (Gap 6)
+    sourceLine is set on keys extracted via regex fallback path
+    sourceLine is set on keys extracted via XML parser path
+    duplicate keys report different sourceLines
+    qualified scope alias inherits sourceLine from original definition
+
+scope explosion cap (Gap 7)
+    multi-token @keyscope on submap registers qualified aliases for each token
+    nested multi-token keyscopes produce cross-product qualified aliases
+    scope explosion warning is set when MAX_KEY_SPACE_ENTRIES is exceeded
 ```

--- a/docs/KEYSPACE-IMPROVEMENT-PLAN.md
+++ b/docs/KEYSPACE-IMPROVEMENT-PLAN.md
@@ -1,0 +1,328 @@
+# Keyspace Algorithm Improvement Plan
+
+*Analysis based on pydita reference implementation (github.com/jyjeanne/pydita)*
+
+---
+
+## Executive Summary
+
+The pydita Python library implements a rigorous DITA key space construction algorithm
+that matches the DITA 1.3/2.0 specification more completely than the current ditacraft
+implementation. This document maps the gaps and defines a phased improvement plan.
+
+---
+
+## 1. Algorithm Comparison
+
+### 1.1 pydita Architecture
+
+pydita builds key spaces in **three ordered phases**:
+
+| Phase | What it does |
+|-------|--------------|
+| **Phase 1 – BFS traversal** | Walk the resolved map tree; create a `KeySpace` node for every scope-defining element (`@keyscope`). Add key definitions to the nearest enclosing scope. |
+| **Phase 2 – PullUp** | Walk the `KeySpace` tree bottom-up. Copy scope-qualified key names (e.g. `childScope.key`) from every child scope into its parent scope, recursively up to the root. |
+| **Phase 3 – PushDown** | Walk the `KeySpace` tree top-down. Push ancestor key definitions into descendant scopes so that, from within a child scope, unqualified ancestor keys resolve correctly. |
+
+Key data structures:
+
+```python
+KeyDefinition
+    keyName: str
+    keydefElems: list[Element]   # priority-ordered list of key-defining elements
+    keySpace: KeySpace            # owning scope
+
+KeySpace
+    keyScopeNames: set[str]
+    keydefsByKeyName: dict[str, list[KeyDefinition]]   # key name → priority list
+    keyspacesByScopeName: dict[str, list[KeySpace]]    # child scopes by name
+    keyspacesByDefiner: dict[Element, KeySpace]        # definer elem → space
+    peerKeyscopes: dict[str, list[Element]]            # peer map refs by scope name
+    _isDeferred: bool                                  # lazy-load flag
+```
+
+`resolveKey(keyName, mapcontext)` walks up from the element's containing scope to
+find the definition, following `@keyref` chains with a configurable hop limit (default 3).
+
+### 1.2 ditacraft Architecture (current)
+
+ditacraft uses a **single-phase BFS** that builds a flat `Map<string, KeyDefinition>`.
+Scope prefixes are computed inline during traversal using a cross-product helper.
+
+```typescript
+KeySpace {
+    keys: Map<string, KeyDefinition>   // key name → single winning definition
+    duplicateKeys: Map<string, KeyDefinition[]>
+    subjectSchemePaths: string[]
+}
+```
+
+`resolveKey(keyName)` is a direct `Map.get(keyName)` lookup — no scope context,
+no keyref chain following.
+
+---
+
+## 2. Gap Analysis
+
+### Gap 1 — No PushDown Pass (missing scope inheritance) ★★★
+
+**What is missing**: Ancestor keys are not pushed into descendant scopes.
+
+**Impact**: Within a nested scope, unqualified references to keys defined in an ancestor
+scope may fail to resolve if the key was not re-defined inside the child scope.
+
+**DITA spec reference**: DITA 1.3 §2.4.4 — "Keys in a scope can be referenced using the
+unqualified key name from within the same scope or any descendant scope."
+
+**pydita solution**: `PushDownVisitor` traverses the `KeySpace` tree top-down and calls
+`addKeyDefinitions()` on each child scope with the parent's definitions (lower priority).
+
+**ditacraft fix**: After the BFS builds per-scope key dictionaries, add a second pass that
+walks down the scope tree and merges ancestor key definitions (at lower priority) into
+each descendant scope's flat map.
+
+---
+
+### Gap 2 — No Keyref Chain Resolution ★★★
+
+**What is missing**: When a key definition carries `@keyref="otherKey"`, resolving the
+original key does not follow through to the target.
+
+**Impact**: Indirect key definitions (used heavily for content reuse and product
+variants) return the intermediate keydef element instead of the final resource.
+
+**pydita solution**: `KeySpace.resolveKey()` checks for `@keyref` on the keydef element
+and recurses with `hopsRemaining -= 1`, stopping at 0 to prevent cycles.
+
+```python
+keyref = definer.get("keyref")
+if keyref is not None and hopsRemaining:
+    return self.resolveKey(keyref, mapcontext=definer, hopsRemaining=hopsRemaining-1)
+```
+
+**ditacraft fix** (`keySpaceService.ts` → `resolveKey` / `buildKeySpace`):
+
+```typescript
+// When returning a KeyDefinition, check for a keyref attribute on the definer element.
+// If present, and hopsRemaining > 0, recurse:
+private followKeyrefChain(keyDef: KeyDefinition, hops = 3): KeyDefinition | null {
+    if (!keyDef.keyref || hops <= 0) return keyDef;
+    const next = keySpace.keys.get(keyDef.keyref);
+    return next ? this.followKeyrefChain(next, hops - 1) : keyDef;
+}
+```
+
+This requires adding a `keyref?: string` field to the `KeyDefinition` interface and
+populating it during `extractKeyDefinitions()`.
+
+---
+
+### Gap 3 — Context-Free Key Resolution ★★
+
+**What is missing**: `resolveKey(keyName, contextFilePath)` ignores the scope context of
+the authoring file. It cannot determine which child scope the context file belongs to
+and therefore cannot give priority to scope-local key definitions.
+
+**Impact**: When two sibling scopes define the same unqualified key name, the effective
+definition depends entirely on BFS traversal order rather than the authoring context.
+
+**pydita solution**: `KeySpace.resolveKey(keyName, mapcontext)` walks from the element's
+`mapcontext` up through `keyspacesByDefiner` to find the innermost enclosing scope, then
+resolves within that scope before bubbling up.
+
+**ditacraft fix**: Build a reverse index `topicToScope: Map<string, string>` that maps
+each topic file path to the scope it belongs to. Then in `resolveKey`, look up the
+scope for `contextFilePath` and prefer its definitions.
+
+---
+
+### Gap 4 — Single Winning Definition (no priority list) ★★
+
+**What is missing**: For each key name, only the first-encountered definition is stored.
+The server tracks duplicates separately but they are not integrated into the resolution
+pipeline.
+
+**Impact**: Tooling cannot offer the full analysis (e.g., showing all overrides and
+which one wins at a given authoring context) that is available in pydita.
+
+**pydita solution**: `keydefsByKeyName: dict[str, list[KeyDefinition]]` stores all
+definitions in priority order. `getKeyDefiner()` returns `keydefElems[0]` for resolution
+but callers can inspect the full priority list.
+
+**ditacraft fix**: Extend `KeySpace` with a `priorityKeys: Map<string, KeyDefinition[]>`.
+The `KeySpaceViewProvider` "Duplicate Keys" tree node can then surface the full priority
+chain, not just the pair of (winner, first duplicate).
+
+---
+
+### Gap 5 — Deferred Peer Map Loading (missing lazy init) ★
+
+**What is missing**: Peer maps (`@scope="peer"`) are skipped during BFS. Their key spaces
+are never constructed, even on demand.
+
+**Impact**: Cross-map key references from content that relies on peer maps always resolve
+to `undefined`, even when the referenced map is available on disk.
+
+**pydita solution**: `KeyspaceManager.addDeferredKeyspace()` registers a deferred
+`KeySpace` (with `_isDeferred = True`) for every peer mapref. The first resolution
+attempt against a deferred space triggers `constructDeferredKeyspace()`.
+
+**ditacraft fix**: During BFS, when a `@scope="peer"` + `@keyscope` + `@href` mapref
+is found, register it in a `deferredPeerMaps: Map<string, string>` (scope name → map
+path). On a cache miss in `resolveKey`, attempt to load and merge the peer map's key
+space before returning `null`.
+
+---
+
+### Gap 6 — Regex XML Parsing vs. DTD-Aware Parser ★
+
+**What is missing**: ditacraft extracts key definitions with regular expressions rather
+than a proper XML parser.
+
+**Impact**: Edge cases — keys split across continuation lines, CDATA with embedded
+angle brackets, attribute ordering variations, namespace prefixes — may cause missed
+or incorrect extractions.
+
+**pydita solution**: Uses `lxml` with DITA OT catalog for DTD-aware parsing; element
+class matching via `@class` attribute (`ditautils.isClass(elem, "map/topicref")`).
+
+**ditacraft fix**: Opportunistic — the existing `stripCommentsAndCDATA()` pre-processor
+already eliminates many edge cases. Full XML parsing would require bundling a lightweight
+parser (e.g., `fast-xml-parser` already used in the validation pipeline). This should
+be done when the regex approach produces demonstrable failures.
+
+---
+
+## 3. Implementation Plan
+
+### Phase 1 — Keyref Chain Resolution (High value, low risk)
+
+**Target**: `server/src/services/keySpaceService.ts` + `src/utils/keySpaceResolver.ts`
+
+Steps:
+1. Add `keyref?: string` to `KeyDefinition` interface.
+2. In `extractKeyDefinitions()`, capture `@keyref` attribute from each keydef element.
+3. Add private `followKeyrefChain(keyDef, keys, hops=3)` helper that follows the chain
+   with hop limiting and cycle detection.
+4. Call `followKeyrefChain` inside `resolveKey()` before returning.
+5. Add unit tests: direct key → key with keyref → indirect keyref chain → cycle guard.
+
+**Estimated effort**: 1–2 days  
+**Risk**: Low — purely additive, no restructuring.
+
+---
+
+### Phase 2 — PushDown Scope Inheritance
+
+**Target**: `server/src/services/keySpaceService.ts`
+
+Steps:
+1. During BFS, build a parallel scope tree:
+   ```typescript
+   interface ScopeNode {
+       scopeNames: string[];
+       scopePrefixes: string[];      // fully-qualified scope path
+       keys: Map<string, KeyDefinition>;
+       children: ScopeNode[];
+   }
+   ```
+2. After BFS completes, do a top-down tree walk. For each `ScopeNode`, merge parent
+   keys into the child's key map (at lower priority — `Map.set` only if not already
+   present).
+3. Then flatten the scope tree back into `keySpace.keys`, including both unqualified
+   (relative to each scope) and fully-qualified variants.
+4. Update tests in `keySpaceService.test.ts` to cover ancestor key resolution from
+   within nested scopes.
+
+**Estimated effort**: 3–4 days  
+**Risk**: Medium — changes BFS result shape; existing tests will guard regressions.
+
+---
+
+### Phase 3 — Context-Aware Resolution + Priority Lists
+
+**Target**: `server/src/services/keySpaceService.ts`, `KeySpaceService` public API
+
+Steps:
+1. During BFS, build `topicToScope: Map<string, ScopeNode>` (topic path → owning scope).
+2. Change `resolveKey(keyName, contextFilePath)` to:
+   a. Look up the scope node for `contextFilePath`.
+   b. Try `scopeNode.keys.get(keyName)`.
+   c. If not found, walk up `scopeNode` ancestors.
+   d. Fall back to root scope.
+3. Extend `KeySpace.priorityKeys: Map<string, KeyDefinition[]>` for tooling.
+4. Expose in `getDuplicateKeys()` + update `KeySpaceViewProvider` tree.
+
+**Estimated effort**: 4–5 days  
+**Risk**: Medium — changes public API of `resolveKey`; all callers (completion, hover,
+definition, diagnostics) need to pass `contextFilePath`, which most already do.
+
+---
+
+### Phase 4 — Deferred Peer Map Loading
+
+**Target**: `server/src/services/keySpaceService.ts`
+
+Steps:
+1. During BFS, detect `@scope="peer" @keyscope @href` maprefs and register them in
+   `deferredPeers: Map<string, string>` (scope name → absolute map path).
+2. In `resolveKey`, after failing local lookup, check if `keyName` starts with a known
+   peer scope prefix. If so, lazily call `buildKeySpace(peerMapPath)` and merge.
+3. Cache peer map key spaces under their root map path (reuses existing cache).
+4. Add integration tests with a fixture workspace that has a peer map.
+
+**Estimated effort**: 3–4 days  
+**Risk**: Low-Medium — isolated to the resolution path; does not affect main BFS.
+
+---
+
+## 4. Priority Summary
+
+| # | Gap | Impact | Effort | Phase |
+|---|-----|--------|--------|-------|
+| 2 | Keyref chain resolution | High | Low | 1 |
+| 1 | PushDown scope inheritance | High | Medium | 2 |
+| 3 | Context-aware resolution | Medium | Medium | 3 |
+| 4 | Priority list per key | Medium | Low | 3 |
+| 5 | Deferred peer map loading | Medium | Medium | 4 |
+| 6 | XML parser replacement | Low | High | Backlog |
+
+---
+
+## 5. Files Affected
+
+| File | Changes |
+|------|---------|
+| `server/src/services/keySpaceService.ts` | Phases 1–4 (main logic) |
+| `src/utils/keySpaceResolver.ts` | Phase 1 (keyref chain, client mirror) |
+| `server/src/services/interfaces.ts` | Extended `IKeySpaceService` signature |
+| `server/src/test/keySpaceService.test.ts` | New test cases for all phases |
+| `src/test/keySpaceResolver.test.ts` | New test cases for phase 1 |
+| `docs/KEY-SPACE-RESOLUTION.md` | Update spec to match new behaviour |
+
+---
+
+## 6. Test Fixtures Needed
+
+The following DITA fixture files should be added to the test suite to validate new
+behaviour:
+
+```
+test/fixtures/keyspace/
+    peer-scope/
+        root.ditamap          # references peer.ditamap as @scope="peer" @keyscope="peer"
+        peer.ditamap          # defines key "peer-key"
+    keyref-chain/
+        root.ditamap          # key "alias" → @keyref="real", key "real" → href
+    scope-inheritance/
+        root.ditamap          # defines key "shared" at root scope
+        child-scope.ditamap   # @keyscope="child", does NOT redefine "shared"
+    scope-override/
+        root.ditamap          # defines key "shared" at root AND in child scope
+        child-scope.ditamap   # @keyscope="child", overrides "shared"
+```
+
+---
+
+*Reference: pydita source — `src/pydita/keyspace.py`, `src/pydita/keyspacemgr.py`,
+`src/pydita/keyspacevisitors.py` (branch: develop)*

--- a/docs/KEYSPACE_BUGS_TO_FIX.md
+++ b/docs/KEYSPACE_BUGS_TO_FIX.md
@@ -1,0 +1,20 @@
+## list of keyspace bugs to fix
+
+1. Bug 1 — HIGH (Logic): Wrong followKeyrefChain scope prefix for peer map keys
+resolveKey calls followKeyrefChain(peerDef, peerKeySpace.keys, '') for all peer resolutions. When the peer key lives
+  inside a named scope (e.g. inner.someKey), the chain follower needs scopePrefix = 'inner' to find inner.nextKey before
+   falling back to the unqualified name. Passing '' means any keyref chain within a scoped peer section silently
+  resolves against the wrong scope.
+
+2.  Bug 2 — HIGH (Performance): new XMLParser() on every extractKeyDefinitions call
+  parseMapElements instantiates a fresh XMLParser on every map file and every inline-scope block. The parser is
+  stateless; it should be a class-level singleton.
+
+3.  Bug 3 — MEDIUM (Correctness): extractMetadataFromNode doesn't guard against topicmeta as an array
+  When fxp encounters multiple <topicmeta> elements (invalid DITA but parseable), it returns an array. The check typeof
+  raw !== 'object' passes for arrays, so the array is cast as Record<string, unknown> and every property access returns
+  undefined — silently losing all metadata.
+
+4.  Bug 4 — MEDIUM (Cleanliness): collectXmlElements recurses unnecessarily into XML PI nodes (?xml)
+  The ?xml pseudo-key emitted by fxp for the XML declaration is not an element but gets treated as one, causing
+  unnecessary object traversal and a spurious entry in the output array.

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "typescript-eslint": "^8.58.2"
       },
       "engines": {
-        "vscode": "^1.82.0"
+        "vscode": "^1.115.0"
       }
     },
     "node_modules/@azu/format-text": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/jyjeanne/ditacraft#readme",
   "engines": {
-    "vscode": "^1.82.0"
+    "vscode": "^1.115.0"
   },
   "categories": [
     "Programming Languages",

--- a/server/src/services/interfaces.ts
+++ b/server/src/services/interfaces.ts
@@ -5,7 +5,8 @@
  */
 
 import { Diagnostic } from 'vscode-languageserver/node';
-import { KeyDefinition, KeySpace } from './keySpaceService';
+import { KeyDefinition, KeyResolutionReport, KeySpace } from './keySpaceService';
+export type { KeyResolutionReport };
 
 // ---------------------------------------------------------------------------
 // IKeySpaceService
@@ -29,6 +30,12 @@ export interface IKeySpaceService {
      * Finds the root map, builds (or retrieves cached) key space, then looks up key.
      */
     resolveKey(keyName: string, contextFilePath: string): Promise<KeyDefinition | null>;
+
+    /**
+     * Resolve a key and return a detailed trace explaining which definition
+     * was chosen and why, including every lookup step and any keyref chain followed.
+     */
+    explainKey(keyName: string, contextFilePath: string): Promise<KeyResolutionReport>;
 
     /**
      * Returns all keys from the key space for the given context file.

--- a/server/src/services/keySpaceService.ts
+++ b/server/src/services/keySpaceService.ts
@@ -23,6 +23,8 @@ export interface KeyDefinition {
     sourceMap: string;
     scope?: string;
     processingRole?: string;
+    /** Indirect key reference: when set, resolution follows the chain to this key name. */
+    keyref?: string;
     metadata?: KeyMetadata;
 }
 
@@ -41,6 +43,12 @@ export interface KeySpace {
     subjectSchemePaths: string[];
     /** Keys defined more than once. Maps key name → all definitions (including the effective first one). */
     duplicateKeys: Map<string, KeyDefinition[]>;
+    /**
+     * Maps each topic file path (normalised) to its primary scope prefix.
+     * Used by resolveKey() to perform context-aware scope lookup before
+     * falling back to the flat unqualified key name.
+     */
+    topicToScope: Map<string, string>;
 }
 
 interface CacheConfig {
@@ -141,7 +149,27 @@ export class KeySpaceService implements IKeySpaceService {
         }
 
         const keySpace = await this.buildKeySpace(rootMap);
-        return keySpace.keys.get(keyName) ?? null;
+
+        // Context-aware resolution: when the authoring file lives inside a named
+        // scope, prefer the scope-qualified key (e.g. "product.lib.version") over
+        // the root-level unqualified key ("version").  The PushDown pass has already
+        // added inherited ancestor keys under the child scope namespace, so a child
+        // scope override always beats an ancestor definition at this lookup point.
+        const scopePrefix = keySpace.topicToScope.get(path.normalize(contextFilePath));
+        if (scopePrefix) {
+            const qualifiedName = `${scopePrefix}.${keyName}`;
+            const scopedDef = keySpace.keys.get(qualifiedName);
+            if (scopedDef) {
+                return this.followKeyrefChain(scopedDef, keySpace.keys);
+            }
+        }
+
+        // Fall back to the context-free (root-scope) entry.
+        const keyDef = keySpace.keys.get(keyName) ?? null;
+        if (keyDef) {
+            return this.followKeyrefChain(keyDef, keySpace.keys);
+        }
+        return null;
     }
 
     /**
@@ -362,11 +390,10 @@ export class KeySpaceService implements IKeySpaceService {
             mapHierarchy: [],
             subjectSchemePaths: [],
             duplicateKeys: new Map(),
+            topicToScope: new Map(),
         };
 
         const visited = new Set<string>();
-        // Each queue entry carries an array of scope prefixes (combinatorial).
-        // An empty array means no scope; each string is one fully-qualified prefix path.
         const queue: { mapPath: string; scopePrefixes: string[] }[] = [
             { mapPath: absoluteRootPath, scopePrefixes: [] },
         ];
@@ -378,6 +405,11 @@ export class KeySpaceService implements IKeySpaceService {
         } catch {
             // Use default
         }
+
+        // Tracks the highest-priority key definition per key name per scope prefix.
+        // The PushDown pass uses this to propagate ancestor-scope keys into
+        // descendant scope namespaces (e.g. "product.lib.version" from "product.version").
+        const scopeDirectKeys = new Map<string, KeyDefinition[]>();
 
         while (queue.length > 0) {
             const { mapPath: currentMap, scopePrefixes } = queue.shift()!;
@@ -393,22 +425,29 @@ export class KeySpaceService implements IKeySpaceService {
 
             try {
                 const rawContent = await fsPromises.readFile(currentMap, 'utf-8');
-                // Strip comments and CDATA to avoid false matches
                 const mapContent = stripCommentsAndCDATA(rawContent);
 
-                // Detect keyscope(s) on root element of this map
                 const rootScopes = this.extractRootKeyscope(mapContent);
-                // Combine parent prefixes with root-level scopes (cross product)
                 const effectivePrefixes = this.combineScopePrefixes(scopePrefixes, rootScopes);
+                // The primary prefix is the first (canonical) scope path for this map.
+                const primaryPrefix = effectivePrefixes[0] ?? '';
 
-                // Extract key definitions — first definition wins
+                if (!scopeDirectKeys.has(primaryPrefix)) {
+                    scopeDirectKeys.set(primaryPrefix, []);
+                }
+
                 const keys = this.extractKeyDefinitions(mapContent, currentMap, maxLinkMatches);
                 for (const keyDef of keys) {
-                    // Store unqualified key name (first definition wins)
+                    // Record as a direct key of this scope (first per key name wins).
+                    const directKeys = scopeDirectKeys.get(primaryPrefix)!;
+                    if (!directKeys.some(k => k.keyName === keyDef.keyName)) {
+                        directKeys.push(keyDef);
+                    }
+
+                    // Unqualified entry — first definition across the whole key space wins.
                     if (!keySpace.keys.has(keyDef.keyName)) {
                         keySpace.keys.set(keyDef.keyName, keyDef);
                     } else {
-                        // Track duplicate key definitions
                         let dups = keySpace.duplicateKeys.get(keyDef.keyName);
                         if (!dups) {
                             dups = [keySpace.keys.get(keyDef.keyName)!];
@@ -416,34 +455,53 @@ export class KeySpaceService implements IKeySpaceService {
                         }
                         dups.push(keyDef);
                     }
-                    // Store scope-qualified key names (e.g., "a.x.keyname", "b.x.keyname")
+
+                    // Scope-qualified entries — first definition per qualified name wins.
                     for (const prefix of effectivePrefixes) {
                         const qualifiedName = `${prefix}.${keyDef.keyName}`;
                         if (!keySpace.keys.has(qualifiedName)) {
-                            keySpace.keys.set(qualifiedName, {
-                                ...keyDef,
-                                keyName: qualifiedName,
-                            });
+                            keySpace.keys.set(qualifiedName, { ...keyDef, keyName: qualifiedName });
                         }
                     }
                 }
 
-                // Detect subject scheme maps (root element is <subjectScheme>)
+                // Record which scope each referenced topic belongs to.
+                // This is used later in resolveKey() for context-aware lookup.
+                this.extractTopicReferences(
+                    mapContent, currentMap, primaryPrefix, keySpace.topicToScope, maxLinkMatches
+                );
+
                 if (this.isSubjectSchemeMap(rawContent)) {
                     keySpace.subjectSchemePaths.push(currentMap);
                 }
 
-                // Queue submaps (inherit scope prefixes + detect new scopes)
                 const submaps = this.extractMapReferences(mapContent, currentMap, maxLinkMatches);
                 for (const submap of submaps) {
                     const childPrefixes = this.combineScopePrefixes(effectivePrefixes, submap.keyscopes);
-                    queue.push({
-                        mapPath: submap.path,
-                        scopePrefixes: childPrefixes,
-                    });
+                    queue.push({ mapPath: submap.path, scopePrefixes: childPrefixes });
                 }
             } catch {
                 // Error reading/parsing map, skip
+            }
+        }
+
+        // PushDown pass: for every child scope, inherit ancestor-scope key definitions
+        // at lower priority.  This ensures that a key defined in an ancestor scope (e.g.
+        // "product.version") is resolvable via its fully-qualified child-scope name (e.g.
+        // "product.lib.version") when authoring within the "lib" child scope.
+        // Keys already defined in the child scope (added during BFS) are not overwritten.
+        for (const [childPrefix] of scopeDirectKeys) {
+            if (childPrefix === '') continue;
+            const parts = childPrefix.split('.');
+            // Walk ancestor depths from root (depth=0 → '') up to the immediate parent.
+            for (let depth = 0; depth < parts.length; depth++) {
+                const ancestorPrefix = parts.slice(0, depth).join('.');
+                for (const ancestorKey of scopeDirectKeys.get(ancestorPrefix) ?? []) {
+                    const inheritedName = `${childPrefix}.${ancestorKey.keyName}`;
+                    if (!keySpace.keys.has(inheritedName)) {
+                        keySpace.keys.set(inheritedName, { ...ancestorKey, keyName: inheritedName });
+                    }
+                }
             }
         }
 
@@ -509,6 +567,10 @@ export class KeySpaceService implements IKeySpaceService {
                 // Extract processing-role
                 const roleMatch = fullElement.match(/\bprocessing-role\s*=\s*["']([^"']+)["']/i);
                 if (roleMatch) keyDef.processingRole = roleMatch[1];
+
+                // Extract keyref (indirect key alias — resolution follows the chain)
+                const keyrefMatch = fullElement.match(/\bkeyref\s*=\s*["']([^"']+)["']/i);
+                if (keyrefMatch) keyDef.keyref = keyrefMatch[1];
 
                 // Extract metadata from <topicmeta> child (navtitle, keywords, shortdesc)
                 // Skip metadata extraction for self-closing elements (no child content)
@@ -603,6 +665,61 @@ export class KeySpaceService implements IKeySpaceService {
             metadata: hasMetadata ? metadata : null,
             inlineContent,
         };
+    }
+
+    /**
+     * Follow @keyref chains up to hopsRemaining hops.
+     * Returns the original definition unchanged when no chain exists, the chain
+     * is broken (target key missing), or the hop limit / cycle guard fires.
+     */
+    private followKeyrefChain(
+        keyDef: KeyDefinition,
+        keys: Map<string, KeyDefinition>,
+        hopsRemaining = 3,
+        visited = new Set<string>()
+    ): KeyDefinition {
+        if (!keyDef.keyref || hopsRemaining <= 0 || visited.has(keyDef.keyName)) {
+            return keyDef;
+        }
+        visited.add(keyDef.keyName);
+        const next = keys.get(keyDef.keyref);
+        if (!next) return keyDef;
+        return this.followKeyrefChain(next, keys, hopsRemaining - 1, visited);
+    }
+
+    /**
+     * Scan a resolved map for topic hrefs (.dita / .xml) and record the
+     * owning scope prefix in topicToScope.  First-seen wins so that topics
+     * referenced at root level are not overwritten by a child-scope reference.
+     * Topics in the root scope (scopePrefix='') are recorded but leave the
+     * context-aware branch in resolveKey() dormant (empty-string check).
+     */
+    private extractTopicReferences(
+        mapContent: string,
+        mapPath: string,
+        scopePrefix: string,
+        topicToScope: Map<string, string>,
+        maxMatches: number
+    ): void {
+        const mapDir = path.dirname(mapPath);
+        const topicRefRegex = new RegExp(
+            `<(\\w+)\\b${TAG_ATTRS}\\bhref\\s*=\\s*["']([^"'#]+\\.(?:dita|xml))(?:#[^"']*)?["']`,
+            'gi'
+        );
+        let match: RegExpExecArray | null;
+        let count = 0;
+        while ((match = topicRefRegex.exec(mapContent)) !== null) {
+            if (++count > maxMatches) break;
+            if (match[1].toLowerCase() === 'mapref') continue;
+            const href = match[2];
+            if (href.startsWith('http://') || href.startsWith('https://')) continue;
+            const resolved = path.resolve(mapDir, href);
+            if (!this.isPathWithinWorkspace(resolved)) continue;
+            const normalized = path.normalize(resolved);
+            if (!topicToScope.has(normalized)) {
+                topicToScope.set(normalized, scopePrefix);
+            }
+        }
     }
 
     private extractMapReferences(

--- a/server/src/services/keySpaceService.ts
+++ b/server/src/services/keySpaceService.ts
@@ -160,14 +160,14 @@ export class KeySpaceService implements IKeySpaceService {
             const qualifiedName = `${scopePrefix}.${keyName}`;
             const scopedDef = keySpace.keys.get(qualifiedName);
             if (scopedDef) {
-                return this.followKeyrefChain(scopedDef, keySpace.keys);
+                return this.followKeyrefChain(scopedDef, keySpace.keys, scopePrefix);
             }
         }
 
         // Fall back to the context-free (root-scope) entry.
         const keyDef = keySpace.keys.get(keyName) ?? null;
         if (keyDef) {
-            return this.followKeyrefChain(keyDef, keySpace.keys);
+            return this.followKeyrefChain(keyDef, keySpace.keys, '');
         }
         return null;
     }
@@ -429,19 +429,26 @@ export class KeySpaceService implements IKeySpaceService {
 
                 const rootScopes = this.extractRootKeyscope(mapContent);
                 const effectivePrefixes = this.combineScopePrefixes(scopePrefixes, rootScopes);
-                // The primary prefix is the first (canonical) scope path for this map.
+                // The primary prefix is the first (canonical) scope path for this map,
+                // used for topic-to-scope tracking.  All prefixes (multi-name keyscope)
+                // are used for scopeDirectKeys so PushDown inheritance works for every alias.
                 const primaryPrefix = effectivePrefixes[0] ?? '';
+                const allScopePrefixes = effectivePrefixes.length > 0 ? effectivePrefixes : [''];
 
-                if (!scopeDirectKeys.has(primaryPrefix)) {
-                    scopeDirectKeys.set(primaryPrefix, []);
+                for (const prefix of allScopePrefixes) {
+                    if (!scopeDirectKeys.has(prefix)) {
+                        scopeDirectKeys.set(prefix, []);
+                    }
                 }
 
                 const keys = this.extractKeyDefinitions(mapContent, currentMap, maxLinkMatches);
                 for (const keyDef of keys) {
-                    // Record as a direct key of this scope (first per key name wins).
-                    const directKeys = scopeDirectKeys.get(primaryPrefix)!;
-                    if (!directKeys.some(k => k.keyName === keyDef.keyName)) {
-                        directKeys.push(keyDef);
+                    // Record as a direct key of every scope alias (first per key name wins).
+                    for (const prefix of allScopePrefixes) {
+                        const directKeys = scopeDirectKeys.get(prefix)!;
+                        if (!directKeys.some(k => k.keyName === keyDef.keyName)) {
+                            directKeys.push(keyDef);
+                        }
                     }
 
                     // Unqualified entry — first definition across the whole key space wins.
@@ -675,6 +682,7 @@ export class KeySpaceService implements IKeySpaceService {
     private followKeyrefChain(
         keyDef: KeyDefinition,
         keys: Map<string, KeyDefinition>,
+        scopePrefix = '',
         hopsRemaining = 3,
         visited = new Set<string>()
     ): KeyDefinition {
@@ -682,9 +690,12 @@ export class KeySpaceService implements IKeySpaceService {
             return keyDef;
         }
         visited.add(keyDef.keyName);
-        const next = keys.get(keyDef.keyref);
+        // Prefer the scope-qualified target so that keyref chains within a named
+        // scope resolve to the scope's own override rather than the root definition.
+        const next = (scopePrefix ? keys.get(`${scopePrefix}.${keyDef.keyref}`) : undefined)
+            ?? keys.get(keyDef.keyref);
         if (!next) return keyDef;
-        return this.followKeyrefChain(next, keys, hopsRemaining - 1, visited);
+        return this.followKeyrefChain(next, keys, scopePrefix, hopsRemaining - 1, visited);
     }
 
     /**
@@ -710,7 +721,7 @@ export class KeySpaceService implements IKeySpaceService {
         let count = 0;
         while ((match = topicRefRegex.exec(mapContent)) !== null) {
             if (++count > maxMatches) break;
-            if (match[1].toLowerCase() === 'mapref') continue;
+            if (['mapref', 'keydef', 'subjectdef'].includes(match[1].toLowerCase())) continue;
             const href = match[2];
             if (href.startsWith('http://') || href.startsWith('https://')) continue;
             const resolved = path.resolve(mapDir, href);

--- a/server/src/services/keySpaceService.ts
+++ b/server/src/services/keySpaceService.ts
@@ -9,6 +9,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import { promises as fsPromises } from 'fs';
 
+import { XMLParser } from 'fast-xml-parser';
 import { TAG_ATTRS } from '../utils/patterns';
 import { stripCommentsAndCDATA } from '../utils/textUtils';
 import { IKeySpaceService } from './interfaces';
@@ -21,6 +22,8 @@ export interface KeyDefinition {
     elementId?: string;
     inlineContent?: string;
     sourceMap: string;
+    /** 1-based line number of the key-defining element within sourceMap. */
+    sourceLine?: number;
     scope?: string;
     processingRole?: string;
     /** Indirect key reference: when set, resolution follows the chain to this key name. */
@@ -32,6 +35,38 @@ export interface KeyMetadata {
     navtitle?: string;
     keywords?: string[];
     shortdesc?: string;
+}
+
+/** One lookup step recorded during key resolution explain mode. */
+export interface ResolutionStep {
+    /** The type of lookup attempted. */
+    type: 'context-scope-lookup' | 'unqualified-lookup' | 'peer-map-lookup' | 'keyref-hop';
+    /** The exact key name that was looked up at this step. */
+    attempted: string;
+    /** Whether this step produced a match. */
+    found: boolean;
+    /** The definition matched at this step (undefined when not found). */
+    definition?: KeyDefinition;
+    /** Human-readable explanation of what happened and why. */
+    note: string;
+}
+
+/** Detailed report produced by explainKey(). */
+export interface KeyResolutionReport {
+    keyName: string;
+    contextFilePath: string;
+    /** Scope prefix of the context file (e.g. "product.lib"), if any. */
+    contextScope?: string;
+    /** The winning definition, or null when the key is not found. */
+    resolvedDefinition: KeyDefinition | null;
+    /** Ordered list of lookup steps, including failed attempts. */
+    steps: ResolutionStep[];
+    /**
+     * Key names traversed by following @keyref chains, in hop order.
+     * ["alias", "real"] means alias @keyref→ real (no further chain).
+     * Empty when no keyref chain was followed.
+     */
+    keyrefChain: string[];
 }
 
 export interface KeySpace {
@@ -49,6 +84,17 @@ export interface KeySpace {
      * falling back to the flat unqualified key name.
      */
     topicToScope: Map<string, string>;
+    /**
+     * Peer maps encountered during BFS that are NOT inlined into this key space.
+     * Maps keyscope-name → absolute map path.  Populated for maprefs with
+     * @scope="peer" + @keyscope; loaded lazily in resolveKey() on cache miss.
+     */
+    deferredPeerMaps: Map<string, string>;
+    /**
+     * Set to true when the number of qualified scope aliases exceeded
+     * MAX_KEY_SPACE_ENTRIES.  Additional aliases were silently dropped.
+     */
+    scopeExplosionWarning?: boolean;
 }
 
 interface CacheConfig {
@@ -67,6 +113,8 @@ const ONE_MINUTE_MS = 60_000;
 const MAX_KEY_SPACES = 10;
 const MAX_MAP_REFERENCES = 1000;
 const MAX_INLINE_SCOPE_DEPTH = 10;
+/** Cap on total qualified scope-alias entries to guard against combinatorial explosion. */
+const MAX_KEY_SPACE_ENTRIES = 50_000;
 const ROOT_MAP_CACHE_TTL_MS = ONE_MINUTE_MS;
 const FILE_WATCHER_DEBOUNCE_MS = 300;
 const MIN_CLEANUP_INTERVAL_MS = 5 * ONE_MINUTE_MS;
@@ -78,6 +126,15 @@ export class KeySpaceService implements IKeySpaceService {
     private workspaceFolders: string[];
     private getSettings: () => Promise<KeySpaceSettings>;
     private log: (msg: string) => void;
+
+    /** Shared XMLParser instance — stateless, safe to reuse across all calls. */
+    private readonly xmlParser = new XMLParser({
+        ignoreAttributes: false,
+        attributeNamePrefix: '@_',
+        parseAttributeValue: false,
+        parseTagValue: false,
+        allowBooleanAttributes: true,
+    });
 
     private keySpaceCache: Map<string, KeySpace> = new Map();
     private rootMapCache: Map<string, { rootMap: string | null; timestamp: number }> = new Map();
@@ -170,7 +227,152 @@ export class KeySpaceService implements IKeySpaceService {
         if (keyDef) {
             return this.followKeyrefChain(keyDef, keySpace.keys, '');
         }
+
+        // Gap 4 — deferred peer map resolution.
+        // Keys in peer maps are accessed as "peerScopeName.actualKey".
+        // Strip the first scope segment and look up the remainder in the peer map's key space.
+        const dotIdx = keyName.indexOf('.');
+        if (dotIdx > 0 && keySpace.deferredPeerMaps.size > 0) {
+            const peerScopeName = keyName.slice(0, dotIdx);
+            const peerKey = keyName.slice(dotIdx + 1);
+            const peerMapPath = keySpace.deferredPeerMaps.get(peerScopeName);
+            if (peerMapPath) {
+                try {
+                    const peerKeySpace = await this.buildKeySpace(peerMapPath);
+                    const peerDef = peerKeySpace.keys.get(peerKey) ?? null;
+                    if (peerDef) {
+                        // Derive the scope prefix from peerKey so that keyref chains
+                        // within a named scope of the peer map resolve correctly.
+                        // e.g. peerKey="inner.realKey" → peerKeyScope="inner"
+                        const lastDot = peerKey.lastIndexOf('.');
+                        const peerKeyScope = lastDot > 0 ? peerKey.slice(0, lastDot) : '';
+                        return this.followKeyrefChain(peerDef, peerKeySpace.keys, peerKeyScope);
+                    }
+                } catch {
+                    // peer map not readable — fall through to null
+                }
+            }
+        }
+
         return null;
+    }
+
+    /**
+     * Resolve a key and return a detailed trace explaining which definition
+     * was chosen and why.  Mirrors resolveKey() exactly but records every
+     * lookup step — including failed attempts — so callers can explain resolution
+     * to users or drive diagnostic messages.
+     */
+    public async explainKey(
+        keyName: string,
+        contextFilePath: string
+    ): Promise<KeyResolutionReport> {
+        const report: KeyResolutionReport = {
+            keyName,
+            contextFilePath,
+            resolvedDefinition: null,
+            steps: [],
+            keyrefChain: [],
+        };
+
+        const rootMap = await this.findRootMap(contextFilePath);
+        if (!rootMap) {
+            report.steps.push({
+                type: 'unqualified-lookup',
+                attempted: keyName,
+                found: false,
+                note: 'No root map found for context file; key space cannot be built',
+            });
+            return report;
+        }
+
+        const keySpace = await this.buildKeySpace(rootMap);
+
+        // Step 1 — context-aware scope lookup
+        const scopePrefix = keySpace.topicToScope.get(path.normalize(contextFilePath));
+        if (scopePrefix) {
+            report.contextScope = scopePrefix;
+            const qualifiedName = `${scopePrefix}.${keyName}`;
+            const scopedDef = keySpace.keys.get(qualifiedName);
+            report.steps.push({
+                type: 'context-scope-lookup',
+                attempted: qualifiedName,
+                found: !!scopedDef,
+                definition: scopedDef,
+                note: scopedDef
+                    ? `Matched scope-qualified "${qualifiedName}" (context scope: "${scopePrefix}")`
+                    : `Tried scope-qualified "${qualifiedName}" (context scope: "${scopePrefix}") — not found`,
+            });
+            if (scopedDef) {
+                const { def: resolved, chain } = this.followKeyrefChainWithTrace(scopedDef, keySpace.keys, scopePrefix);
+                this.appendKeyrefSteps(report.steps, chain, keySpace.keys);
+                report.keyrefChain = chain;
+                report.resolvedDefinition = resolved;
+                return report;
+            }
+        }
+
+        // Step 2 — unqualified (root-scope) lookup
+        const keyDef = keySpace.keys.get(keyName) ?? null;
+        const sourceLabel = keyDef
+            ? `${path.basename(keyDef.sourceMap)}${keyDef.sourceLine ? ':' + keyDef.sourceLine : ''}`
+            : '';
+        report.steps.push({
+            type: 'unqualified-lookup',
+            attempted: keyName,
+            found: !!keyDef,
+            definition: keyDef ?? undefined,
+            note: keyDef
+                ? `Matched unqualified key "${keyName}" — first-BFS-encounter wins (source: ${sourceLabel})`
+                : `Key "${keyName}" not found in key space`,
+        });
+        if (keyDef) {
+            const { def: resolved, chain } = this.followKeyrefChainWithTrace(keyDef, keySpace.keys, '');
+            this.appendKeyrefSteps(report.steps, chain, keySpace.keys);
+            report.keyrefChain = chain;
+            report.resolvedDefinition = resolved;
+            return report;
+        }
+
+        // Step 3 — deferred peer map lookup (Gap 4)
+        const dotIdx = keyName.indexOf('.');
+        if (dotIdx > 0 && keySpace.deferredPeerMaps.size > 0) {
+            const peerScopeName = keyName.slice(0, dotIdx);
+            const peerKey = keyName.slice(dotIdx + 1);
+            const peerMapPath = keySpace.deferredPeerMaps.get(peerScopeName);
+            const peerStep: ResolutionStep = {
+                type: 'peer-map-lookup',
+                attempted: keyName,
+                found: false,
+                note: peerMapPath
+                    ? `Trying peer map for scope "${peerScopeName}": ${path.basename(peerMapPath)}`
+                    : `Scope "${peerScopeName}" is not a registered peer scope`,
+            };
+            report.steps.push(peerStep);
+            if (peerMapPath) {
+                try {
+                    const peerKeySpace = await this.buildKeySpace(peerMapPath);
+                    const peerDef = peerKeySpace.keys.get(peerKey) ?? null;
+                    if (peerDef) {
+                        peerStep.found = true;
+                        peerStep.definition = peerDef;
+                        peerStep.note = `Found "${peerKey}" in peer map "${path.basename(peerMapPath)}"`;
+                        const lastDot = peerKey.lastIndexOf('.');
+                        const peerKeyScope = lastDot > 0 ? peerKey.slice(0, lastDot) : '';
+                        const { def: resolved, chain } = this.followKeyrefChainWithTrace(peerDef, peerKeySpace.keys, peerKeyScope);
+                        this.appendKeyrefSteps(report.steps, chain, peerKeySpace.keys);
+                        report.keyrefChain = chain;
+                        report.resolvedDefinition = resolved;
+                    } else {
+                        peerStep.note = `Key "${peerKey}" not found in peer map "${path.basename(peerMapPath)}"`;
+                    }
+                } catch {
+                    peerStep.note = `Peer map "${path.basename(peerMapPath)}" could not be loaded`;
+                }
+            }
+        }
+
+        return report;
     }
 
     /**
@@ -392,6 +594,7 @@ export class KeySpaceService implements IKeySpaceService {
             subjectSchemePaths: [],
             duplicateKeys: new Map(),
             topicToScope: new Map(),
+            deferredPeerMaps: new Map(),
         };
 
         const visited = new Set<string>();
@@ -477,9 +680,7 @@ export class KeySpaceService implements IKeySpaceService {
                     // Scope-qualified entries — first definition per qualified name wins.
                     for (const prefix of effectivePrefixes) {
                         const qualifiedName = `${prefix}.${keyDef.keyName}`;
-                        if (!keySpace.keys.has(qualifiedName)) {
-                            keySpace.keys.set(qualifiedName, { ...keyDef, keyName: qualifiedName });
-                        }
+                        this.addScopedKeyEntry(keySpace, qualifiedName, { ...keyDef, keyName: qualifiedName });
                     }
                 }
 
@@ -498,6 +699,16 @@ export class KeySpaceService implements IKeySpaceService {
                 // correct child scope prefix).
                 const submaps = this.extractMapReferences(maskedContent, currentMap, maxLinkMatches);
                 for (const submap of submaps) {
+                    // Peer maps are not inlined; register them for lazy resolution on key miss.
+                    if (submap.isPeer) {
+                        for (const scopeName of submap.keyscopes) {
+                            if (!keySpace.deferredPeerMaps.has(scopeName)) {
+                                keySpace.deferredPeerMaps.set(scopeName, submap.path);
+                            }
+                        }
+                        continue;
+                    }
+
                     const childPrefixes = this.combineScopePrefixes(effectivePrefixes, submap.keyscopes);
 
                     // Register @keys defined on the mapref element itself under the child scope prefix.
@@ -518,9 +729,7 @@ export class KeySpaceService implements IKeySpaceService {
                                     directKeys.push(inlineDef);
                                 }
                                 const qualifiedName = `${prefix}.${inlineKeyName}`;
-                                if (!keySpace.keys.has(qualifiedName)) {
-                                    keySpace.keys.set(qualifiedName, { ...inlineDef, keyName: qualifiedName });
-                                }
+                                this.addScopedKeyEntry(keySpace, qualifiedName, { ...inlineDef, keyName: qualifiedName });
                             }
                             if (!keySpace.keys.has(inlineKeyName)) {
                                 keySpace.keys.set(inlineKeyName, inlineDef);
@@ -548,9 +757,7 @@ export class KeySpaceService implements IKeySpaceService {
                 const ancestorPrefix = parts.slice(0, depth).join('.');
                 for (const ancestorKey of scopeDirectKeys.get(ancestorPrefix) ?? []) {
                     const inheritedName = `${childPrefix}.${ancestorKey.keyName}`;
-                    if (!keySpace.keys.has(inheritedName)) {
-                        keySpace.keys.set(inheritedName, { ...ancestorKey, keyName: inheritedName });
-                    }
+                    this.addScopedKeyEntry(keySpace, inheritedName, { ...ancestorKey, keyName: inheritedName });
                 }
             }
         }
@@ -562,7 +769,216 @@ export class KeySpaceService implements IKeySpaceService {
 
     // --- Internal: Key extraction ---
 
+    /**
+     * Parse the preprocessed map XML with fast-xml-parser and return a flat list
+     * of all elements (tag name + attributes).  DOCTYPE is stripped before parsing.
+     * Returns null on parse failure so the caller can fall back to regex extraction.
+     */
+    private parseMapElements(
+        mapContent: string
+    ): Array<{ tagName: string; attrs: Record<string, string>; node: Record<string, unknown> }> | null {
+        // Strip DOCTYPE — fast-xml-parser chokes on internal subsets.
+        const stripped = mapContent.replace(
+            /<!DOCTYPE\s[\s\S]*?(?:\[[\s\S]*?\]\s*)?>|<!DOCTYPE[^>]*>/gi,
+            ''
+        );
+        try {
+            const parsed = this.xmlParser.parse(stripped) as Record<string, unknown>;
+            const results: Array<{ tagName: string; attrs: Record<string, string>; node: Record<string, unknown> }> = [];
+            this.collectXmlElements(parsed, results);
+            return results;
+        } catch {
+            return null;
+        }
+    }
+
+    /**
+     * Recursive element collector for the fast-xml-parser tree.
+     * Strips namespace prefixes from both element names and attribute names.
+     */
+    private collectXmlElements(
+        obj: unknown,
+        out: Array<{ tagName: string; attrs: Record<string, string>; node: Record<string, unknown> }>,
+        tagName = ''
+    ): void {
+        if (typeof obj !== 'object' || obj === null) return;
+        if (Array.isArray(obj)) {
+            for (const item of obj) this.collectXmlElements(item, out, tagName);
+            return;
+        }
+        const node = obj as Record<string, unknown>;
+        if (tagName) {
+            const attrs: Record<string, string> = {};
+            for (const [key, val] of Object.entries(node)) {
+                if (!key.startsWith('@_')) continue;
+                // Strip @_ prefix and optional namespace prefix (ns:name → name)
+                const attrName = key.slice(2).replace(/^\w+:/, '');
+                attrs[attrName] = String(val ?? '');
+            }
+            out.push({ tagName, attrs, node });
+        }
+        for (const [key, val] of Object.entries(node)) {
+            if (key.startsWith('@_') || key === '#text') continue;
+            // Skip XML processing instructions (?xml, ?pi-name) — not elements
+            if (key.startsWith('?')) continue;
+            // Strip element namespace prefix
+            const childName = key.replace(/^\w+:/, '');
+            this.collectXmlElements(val, out, childName);
+        }
+    }
+
+    /**
+     * Extract key metadata from a parsed topicmeta node (fast-xml-parser tree).
+     */
+    private extractMetadataFromNode(
+        node: Record<string, unknown>
+    ): { metadata: KeyMetadata | null; inlineContent: string | null } {
+        const rawTopicmeta = node['topicmeta'];
+        if (!rawTopicmeta || typeof rawTopicmeta !== 'object') return { metadata: null, inlineContent: null };
+        // fxp returns an array when multiple topicmeta elements exist (invalid DITA) — use the first.
+        const raw = Array.isArray(rawTopicmeta) ? rawTopicmeta[0] : rawTopicmeta;
+        if (!raw || typeof raw !== 'object') return { metadata: null, inlineContent: null };
+        const meta = raw as Record<string, unknown>;
+        const metadata: KeyMetadata = {};
+        let inlineContent: string | null = null;
+
+        // navtitle
+        const navtitleRaw = meta['navtitle'];
+        if (typeof navtitleRaw === 'string') {
+            metadata.navtitle = navtitleRaw.trim() || undefined;
+        } else if (navtitleRaw && typeof navtitleRaw === 'object') {
+            const t = (navtitleRaw as Record<string, unknown>)['#text'];
+            if (typeof t === 'string') metadata.navtitle = t.trim() || undefined;
+        }
+
+        // keywords / keyword
+        const kwBlock = meta['keywords'];
+        if (kwBlock && typeof kwBlock === 'object') {
+            const kwRaw = (kwBlock as Record<string, unknown>)['keyword'];
+            const kwList: string[] = [];
+            const addKw = (v: unknown) => {
+                if (typeof v === 'string') kwList.push(v.trim());
+                else if (v && typeof v === 'object') {
+                    const t = (v as Record<string, unknown>)['#text'];
+                    if (typeof t === 'string') kwList.push(t.trim());
+                }
+            };
+            if (Array.isArray(kwRaw)) kwRaw.forEach(addKw);
+            else addKw(kwRaw);
+            if (kwList.length > 0) { metadata.keywords = kwList; inlineContent = kwList[0]; }
+        }
+        if (!inlineContent) {
+            const directKw = meta['keyword'];
+            if (typeof directKw === 'string') {
+                inlineContent = directKw.trim(); metadata.keywords = [inlineContent];
+            }
+        }
+
+        // shortdesc
+        const sdRaw = meta['shortdesc'];
+        if (typeof sdRaw === 'string') metadata.shortdesc = sdRaw.trim() || undefined;
+
+        const hasMetadata = metadata.navtitle || metadata.keywords || metadata.shortdesc;
+        return { metadata: hasMetadata ? metadata : null, inlineContent };
+    }
+
+    /**
+     * Extract key definitions using fast-xml-parser for correctness (multi-line
+     * attributes, namespace-prefixed attributes).  Falls back to regex on parse error.
+     */
     private extractKeyDefinitions(
+        mapContent: string,
+        mapPath: string,
+        maxMatches: number
+    ): KeyDefinition[] {
+        const elements = this.parseMapElements(mapContent);
+        if (elements !== null) {
+            return this.extractKeyDefinitionsFromElements(elements, mapPath, maxMatches, mapContent);
+        }
+        return this.extractKeyDefinitionsRegex(mapContent, mapPath, maxMatches);
+    }
+
+    /** XML-tree-based key extraction (primary path). */
+    private extractKeyDefinitionsFromElements(
+        elements: Array<{ tagName: string; attrs: Record<string, string>; node: Record<string, unknown> }>,
+        mapPath: string,
+        maxMatches: number,
+        mapContent?: string
+    ): KeyDefinition[] {
+        const keys: KeyDefinition[] = [];
+        const mapDir = path.dirname(mapPath);
+        let matchCount = 0;
+        // Running position for forward-scan provenance lookup.
+        let contentSearchPos = 0;
+
+        for (const { attrs, node } of elements) {
+            const keysValue = attrs['keys'];
+            if (!keysValue) continue;
+            if (++matchCount > maxMatches) break;
+
+            // Skip keyscoped submap refs — handled by the BFS inlineKeys mechanism.
+            if (attrs['keyscope'] && /\.(?:ditamap|bookmap)$/i.test(attrs['href'] ?? '')) continue;
+
+            const isSelfClosing = !Object.keys(node).some(k => !k.startsWith('@_') && k !== '#text');
+
+            // Compute the source line by scanning forward from the last match position.
+            // Anchor on 'keys="token' (or single-quote variant) to avoid matching the
+            // bare token inside hrefs, text content, or other attribute values.
+            // Elements are emitted in document order so the scan is monotone O(n) total.
+            let sourceLine: number | undefined;
+            if (mapContent) {
+                const firstToken = keysValue.split(/\s+/)[0];
+                const anchor1 = `keys="${firstToken}`;
+                const anchor2 = `keys='${firstToken}`;
+                const idx1 = mapContent.indexOf(anchor1, contentSearchPos);
+                const idx2 = mapContent.indexOf(anchor2, contentSearchPos);
+                const foundIdx = idx1 >= 0 && idx2 >= 0
+                    ? Math.min(idx1, idx2)
+                    : Math.max(idx1, idx2);
+                if (foundIdx >= 0) {
+                    sourceLine = this.computeLineNumber(mapContent, foundIdx);
+                    contentSearchPos = foundIdx + 1;
+                }
+            }
+
+            const keyNames = keysValue.split(/\s+/).filter(k => k.length > 0);
+            for (const keyName of keyNames) {
+                const keyDef: KeyDefinition = { keyName, sourceMap: mapPath };
+                if (sourceLine !== undefined) keyDef.sourceLine = sourceLine;
+
+                const href = attrs['href'] ?? '';
+                if (href && !href.startsWith('http://') && !href.startsWith('https://')) {
+                    if (href.includes('#')) {
+                        const [filePart, elemId] = href.split('#', 2);
+                        if (filePart) {
+                            const resolved = path.resolve(mapDir, filePart);
+                            if (this.isPathWithinWorkspace(resolved)) keyDef.targetFile = resolved;
+                        }
+                        if (elemId) keyDef.elementId = elemId;
+                    } else {
+                        const resolved = path.resolve(mapDir, href);
+                        if (this.isPathWithinWorkspace(resolved)) keyDef.targetFile = resolved;
+                    }
+                }
+                if (attrs['scope']) keyDef.scope = attrs['scope'];
+                if (attrs['processing-role']) keyDef.processingRole = attrs['processing-role'];
+                if (attrs['keyref']) keyDef.keyref = attrs['keyref'];
+
+                if (!isSelfClosing) {
+                    const metaResult = this.extractMetadataFromNode(node);
+                    if (metaResult.metadata) keyDef.metadata = metaResult.metadata;
+                    if (!keyDef.targetFile && metaResult.inlineContent) {
+                        keyDef.inlineContent = metaResult.inlineContent;
+                    }
+                }
+                keys.push(keyDef);
+            }
+        }
+        return keys;
+    }
+
+    /** Regex-based key extraction (fallback for malformed XML). */
+    private extractKeyDefinitionsRegex(
         mapContent: string,
         mapPath: string,
         maxMatches: number
@@ -589,10 +1005,13 @@ export class KeySpaceService implements IKeySpaceService {
 
             const keyNames = keysValue.split(/\s+/).filter(k => k.length > 0);
 
+            const sourceLine = this.computeLineNumber(mapContent, match.index);
+
             for (const keyName of keyNames) {
                 const keyDef: KeyDefinition = {
                     keyName,
                     sourceMap: mapPath,
+                    sourceLine,
                 };
 
                 // Extract href
@@ -750,6 +1169,62 @@ export class KeySpaceService implements IKeySpaceService {
     }
 
     /**
+     * Like followKeyrefChain but also returns the sequence of key names traversed.
+     * chain is empty when no @keyref exists; otherwise lists every visited key name
+     * including the final destination.
+     */
+    private followKeyrefChainWithTrace(
+        startDef: KeyDefinition,
+        keys: Map<string, KeyDefinition>,
+        scopePrefix: string
+    ): { def: KeyDefinition; chain: string[] } {
+        if (!startDef.keyref) return { def: startDef, chain: [] };
+
+        const chain: string[] = [];
+        let current = startDef;
+        const visited = new Set<string>();
+        let hopsRemaining = 3;
+
+        while (current.keyref && hopsRemaining > 0 && !visited.has(current.keyName)) {
+            visited.add(current.keyName);
+            chain.push(current.keyName);
+            const next = (scopePrefix ? keys.get(`${scopePrefix}.${current.keyref}`) : undefined)
+                ?? keys.get(current.keyref);
+            if (!next) break;
+            current = next;
+            hopsRemaining--;
+        }
+
+        // Append final destination only when it differs from the last pushed entry.
+        // Without this guard, a self-referential keyref (alias → alias) would produce
+        // chain = ["alias", "alias"] with a misleading duplicate.
+        if (chain.length > 0 && current.keyName !== chain[chain.length - 1]) {
+            chain.push(current.keyName);
+        }
+        return { def: current, chain };
+    }
+
+    /** Append one keyref-hop step per transition in `chain` to `steps`. */
+    private appendKeyrefSteps(
+        steps: ResolutionStep[],
+        chain: string[],
+        keys: Map<string, KeyDefinition>
+    ): void {
+        for (let i = 0; i + 1 < chain.length; i++) {
+            const from = chain[i];
+            const to = chain[i + 1];
+            const def = keys.get(to);
+            steps.push({
+                type: 'keyref-hop',
+                attempted: to,
+                found: !!def,
+                definition: def,
+                note: `Followed @keyref: "${from}" → "${to}"`,
+            });
+        }
+    }
+
+    /**
      * Scan a resolved map for topic hrefs (.dita / .xml) and record the
      * owning scope prefix in topicToScope.  First-seen wins so that topics
      * referenced at root level are not overwritten by a child-scope reference.
@@ -788,8 +1263,8 @@ export class KeySpaceService implements IKeySpaceService {
         mapContent: string,
         mapPath: string,
         maxLinkMatches: number
-    ): { path: string; keyscopes: string[]; inlineKeys: string[] }[] {
-        const submaps: { path: string; keyscopes: string[]; inlineKeys: string[] }[] = [];
+    ): { path: string; keyscopes: string[]; inlineKeys: string[]; isPeer: boolean }[] {
+        const submaps: { path: string; keyscopes: string[]; inlineKeys: string[]; isPeer: boolean }[] = [];
         const mapDir = path.dirname(mapPath);
         // Match ANY element with href pointing to a .ditamap or .bookmap file.
         // This covers mapref, topicref, chapter, appendix, part, glossarylist,
@@ -822,7 +1297,11 @@ export class KeySpaceService implements IKeySpaceService {
                 const inlineKeys = keysMatch
                     ? keysMatch[1].split(/\s+/).filter(k => k.length > 0)
                     : [];
-                submaps.push({ path: absolutePath, keyscopes, inlineKeys });
+                // Peer maps with @keyscope are deferred: their key space is not inlined
+                // into the current map but is accessible via "scopeName.keyName" notation.
+                const scopeMatch = match[0].match(/\bscope\s*=\s*["']([^"']+)["']/i);
+                const isPeer = scopeMatch?.[1] === 'peer' && keyscopes.length > 0;
+                submaps.push({ path: absolutePath, keyscopes, inlineKeys, isPeer });
             }
         }
 
@@ -933,6 +1412,34 @@ export class KeySpaceService implements IKeySpaceService {
             }
         }
         return Array.from(combined);
+    }
+
+    /**
+     * Insert a scope-qualified alias entry only when the key space has not yet
+     * reached the combinatorial explosion cap.  Always a no-op when the name
+     * already exists (first-definition wins).
+     */
+    private addScopedKeyEntry(
+        keySpace: KeySpace,
+        qualifiedName: string,
+        def: KeyDefinition
+    ): void {
+        if (keySpace.keys.has(qualifiedName)) return;
+        if (keySpace.keys.size >= MAX_KEY_SPACE_ENTRIES) {
+            keySpace.scopeExplosionWarning = true;
+            return;
+        }
+        keySpace.keys.set(qualifiedName, def);
+    }
+
+    /** Return the 1-based line number for `charIndex` within `content`. */
+    private computeLineNumber(content: string, charIndex: number): number {
+        let line = 1;
+        const end = Math.min(charIndex, content.length);
+        for (let i = 0; i < end; i++) {
+            if (content[i] === '\n') line++;
+        }
+        return line;
     }
 
     // --- Internal: inline scope branch handling ---
@@ -1143,9 +1650,7 @@ export class KeySpaceService implements IKeySpaceService {
                     const directKeys = scopeDirectKeys.get(prefix)!;
                     if (!directKeys.some(k => k.keyName === inlineKeyName)) directKeys.push(inlineDef);
                     const qualifiedName = `${prefix}.${inlineKeyName}`;
-                    if (!keySpace.keys.has(qualifiedName)) {
-                        keySpace.keys.set(qualifiedName, { ...inlineDef, keyName: qualifiedName });
-                    }
+                    this.addScopedKeyEntry(keySpace, qualifiedName, { ...inlineDef, keyName: qualifiedName });
                 }
                 if (!keySpace.keys.has(inlineKeyName)) keySpace.keys.set(inlineKeyName, inlineDef);
             }
@@ -1163,9 +1668,7 @@ export class KeySpaceService implements IKeySpaceService {
                     const directKeys = scopeDirectKeys.get(prefix)!;
                     if (!directKeys.some(k => k.keyName === keyDef.keyName)) directKeys.push(keyDef);
                     const qualifiedName = `${prefix}.${keyDef.keyName}`;
-                    if (!keySpace.keys.has(qualifiedName)) {
-                        keySpace.keys.set(qualifiedName, { ...keyDef, keyName: qualifiedName });
-                    }
+                    this.addScopedKeyEntry(keySpace, qualifiedName, { ...keyDef, keyName: qualifiedName });
                 }
                 if (!keySpace.keys.has(keyDef.keyName)) {
                     keySpace.keys.set(keyDef.keyName, keyDef);
@@ -1188,6 +1691,14 @@ export class KeySpaceService implements IKeySpaceService {
             // Discover submaps inside this block and queue with combined scope prefix
             const blockSubmaps = this.extractMapReferences(maskedBlockContent, mapPath, maxLinkMatches);
             for (const submap of blockSubmaps) {
+                if (submap.isPeer) {
+                    for (const scopeName of submap.keyscopes) {
+                        if (!keySpace.deferredPeerMaps.has(scopeName)) {
+                            keySpace.deferredPeerMaps.set(scopeName, submap.path);
+                        }
+                    }
+                    continue;
+                }
                 const grandchildPrefixes = this.combineScopePrefixes(childPrefixes, submap.keyscopes);
                 if (submap.inlineKeys.length > 0 && grandchildPrefixes.length > 0) {
                     for (const inlineKeyName of submap.inlineKeys) {
@@ -1201,9 +1712,7 @@ export class KeySpaceService implements IKeySpaceService {
                             const directKeys = scopeDirectKeys.get(prefix)!;
                             if (!directKeys.some(k => k.keyName === inlineKeyName)) directKeys.push(inlineDef);
                             const qualifiedName = `${prefix}.${inlineKeyName}`;
-                            if (!keySpace.keys.has(qualifiedName)) {
-                                keySpace.keys.set(qualifiedName, { ...inlineDef, keyName: qualifiedName });
-                            }
+                            this.addScopedKeyEntry(keySpace, qualifiedName, { ...inlineDef, keyName: qualifiedName });
                         }
                         if (!keySpace.keys.has(inlineKeyName)) keySpace.keys.set(inlineKeyName, inlineDef);
                     }
@@ -1251,4 +1760,105 @@ export class KeySpaceService implements IKeySpaceService {
             return false;
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// Standalone reporting utilities
+// ---------------------------------------------------------------------------
+
+/**
+ * Produce a human-readable text report of an entire key space.
+ * Lists keys by scope, highlights duplicates and deferred peer maps.
+ */
+export function reportKeySpace(keySpace: KeySpace): string {
+    const lines: string[] = [];
+    lines.push(`Key Space Report: ${keySpace.rootMap}`);
+    lines.push(`  Built: ${new Date(keySpace.buildTime).toISOString()}`);
+    lines.push(`  Maps processed: ${keySpace.mapHierarchy.length}`);
+    lines.push(`  Total keys: ${keySpace.keys.size}`);
+    if (keySpace.scopeExplosionWarning) {
+        lines.push(`  WARNING: Scope explosion cap reached — some qualified aliases were dropped`);
+    }
+
+    // Group entries by their outermost scope prefix (text before first dot, or '' for root).
+    const byScope = new Map<string, Array<[string, KeyDefinition]>>();
+    for (const [name, def] of keySpace.keys) {
+        const dotIdx = name.indexOf('.');
+        const scope = dotIdx > 0 ? name.slice(0, dotIdx) : '';
+        if (!byScope.has(scope)) byScope.set(scope, []);
+        byScope.get(scope)!.push([name, def]);
+    }
+
+    lines.push('');
+    lines.push('Keys by scope:');
+    for (const scope of Array.from(byScope.keys()).sort()) {
+        lines.push(`  [${scope || 'root'}]`);
+        const entries = byScope.get(scope)!.sort((a, b) => a[0].localeCompare(b[0]));
+        for (const [name, def] of entries) {
+            const target = def.targetFile
+                ? path.basename(def.targetFile)
+                : (def.inlineContent ? `"${def.inlineContent}"` : '(no target)');
+            const lineSuffix = def.sourceLine ? `:${def.sourceLine}` : '';
+            const keyrefSuffix = def.keyref ? ` → keyref:${def.keyref}` : '';
+            lines.push(`    ${name} → ${target}  [${path.basename(def.sourceMap)}${lineSuffix}]${keyrefSuffix}`);
+        }
+    }
+
+    if (keySpace.duplicateKeys.size > 0) {
+        lines.push('');
+        lines.push(`Duplicate keys (${keySpace.duplicateKeys.size}):`);
+        for (const [name, defs] of keySpace.duplicateKeys) {
+            lines.push(`  ${name}  (${defs.length} definitions, first wins):`);
+            defs.forEach((d, i) => {
+                const lineSuffix = d.sourceLine ? `:${d.sourceLine}` : '';
+                const status = i === 0 ? 'effective' : 'shadowed';
+                lines.push(`    [${status}]  ${path.basename(d.sourceMap)}${lineSuffix}`);
+            });
+        }
+    }
+
+    if (keySpace.deferredPeerMaps.size > 0) {
+        lines.push('');
+        lines.push(`Deferred peer maps (${keySpace.deferredPeerMaps.size}):`);
+        for (const [scope, mapPath] of keySpace.deferredPeerMaps) {
+            lines.push(`  ${scope} → ${path.basename(mapPath)}`);
+        }
+    }
+
+    return lines.join('\n');
+}
+
+/**
+ * Render a KeyResolutionReport as human-readable text.
+ * Suitable for hover tooltips, hover documentation, or debug output.
+ */
+export function formatResolutionReport(report: KeyResolutionReport): string {
+    const lines: string[] = [];
+    const status = report.resolvedDefinition ? 'RESOLVED' : 'NOT FOUND';
+    lines.push(`Key resolution: "${report.keyName}"  [${status}]`);
+
+    if (report.contextScope) {
+        lines.push(`  Context scope: ${report.contextScope}`);
+    }
+
+    if (report.resolvedDefinition) {
+        const def = report.resolvedDefinition;
+        const target = def.targetFile
+            ? path.basename(def.targetFile)
+            : (def.inlineContent ? `"${def.inlineContent}"` : '(no target)');
+        const lineSuffix = def.sourceLine ? `:${def.sourceLine}` : '';
+        lines.push(`  Winner: ${target}  [${path.basename(def.sourceMap)}${lineSuffix}]`);
+    }
+
+    if (report.keyrefChain.length > 0) {
+        lines.push(`  Keyref chain: ${report.keyrefChain.join(' → ')}`);
+    }
+
+    lines.push('  Steps:');
+    for (const step of report.steps) {
+        const tick = step.found ? '✓' : '✗';
+        lines.push(`    ${tick} [${step.type}]  ${step.note}`);
+    }
+
+    return lines.join('\n');
 }

--- a/server/src/services/keySpaceService.ts
+++ b/server/src/services/keySpaceService.ts
@@ -1033,8 +1033,29 @@ export class KeySpaceService implements IKeySpaceService {
             if (!nextClose) return null; // Malformed XML
 
             if (nextOpen && nextOpen.index < nextClose.index) {
-                depth++;
-                pos = nextOpen.index + nextOpen[0].length;
+                // Scan forward to the closing '>' of this opening tag to determine
+                // whether it's self-closing (ends with '/>').  Self-closing elements
+                // don't introduce a new nesting level.
+                let scanPos = nextOpen.index + nextOpen[0].length;
+                let inAttrQuote = false;
+                let quoteChar = '';
+                while (scanPos < content.length) {
+                    const ch = content[scanPos];
+                    if (inAttrQuote) {
+                        if (ch === quoteChar) inAttrQuote = false;
+                    } else if (ch === '"' || ch === "'") {
+                        inAttrQuote = true;
+                        quoteChar = ch;
+                    } else if (ch === '>') {
+                        break;
+                    }
+                    scanPos++;
+                }
+                // Check for self-closing: '>' preceded by '/' (ignoring whitespace)
+                let checkPos = scanPos - 1;
+                while (checkPos > nextOpen.index && /\s/.test(content[checkPos])) checkPos--;
+                if (content[checkPos] !== '/') depth++;
+                pos = scanPos + 1;
             } else {
                 depth--;
                 if (depth === 0) {

--- a/server/src/services/keySpaceService.ts
+++ b/server/src/services/keySpaceService.ts
@@ -66,6 +66,7 @@ export interface KeySpaceSettings {
 const ONE_MINUTE_MS = 60_000;
 const MAX_KEY_SPACES = 10;
 const MAX_MAP_REFERENCES = 1000;
+const MAX_INLINE_SCOPE_DEPTH = 10;
 const ROOT_MAP_CACHE_TTL_MS = ONE_MINUTE_MS;
 const FILE_WATCHER_DEBOUNCE_MS = 300;
 const MIN_CLEANUP_INTERVAL_MS = 5 * ONE_MINUTE_MS;
@@ -443,7 +444,15 @@ export class KeySpaceService implements IKeySpaceService {
                     }
                 }
 
-                const keys = this.extractKeyDefinitions(mapContent, currentMap, maxLinkMatches);
+                // Handle inline scope branches (topicrefs with @keyscope that don't
+                // reference an external map).  Returns mapContent with those blocks
+                // blanked out so that child-scope keys are not re-processed here.
+                const maskedContent = this.processInlineScopeBlocks(
+                    mapContent, currentMap, effectivePrefixes,
+                    keySpace, scopeDirectKeys, queue, maxLinkMatches
+                );
+
+                const keys = this.extractKeyDefinitions(maskedContent, currentMap, maxLinkMatches);
                 for (const keyDef of keys) {
                     // Record as a direct key of every scope alias (first per key name wins).
                     for (const prefix of allScopePrefixes) {
@@ -477,14 +486,17 @@ export class KeySpaceService implements IKeySpaceService {
                 // Record which scope each referenced topic belongs to.
                 // This is used later in resolveKey() for context-aware lookup.
                 this.extractTopicReferences(
-                    mapContent, currentMap, primaryPrefix, keySpace.topicToScope, maxLinkMatches
+                    maskedContent, currentMap, primaryPrefix, keySpace.topicToScope, maxLinkMatches
                 );
 
                 if (this.isSubjectSchemeMap(rawContent)) {
                     keySpace.subjectSchemePaths.push(currentMap);
                 }
 
-                const submaps = this.extractMapReferences(mapContent, currentMap, maxLinkMatches);
+                // Use maskedContent so submaps inside inline scope blocks are not
+                // queued again (processInlineScopeBlocks already queued them with the
+                // correct child scope prefix).
+                const submaps = this.extractMapReferences(maskedContent, currentMap, maxLinkMatches);
                 for (const submap of submaps) {
                     const childPrefixes = this.combineScopePrefixes(effectivePrefixes, submap.keyscopes);
 
@@ -921,6 +933,265 @@ export class KeySpaceService implements IKeySpaceService {
             }
         }
         return Array.from(combined);
+    }
+
+    // --- Internal: inline scope branch handling ---
+
+    /**
+     * Find all top-level elements within `content` that carry @keyscope but do NOT
+     * reference an external .ditamap/.bookmap file.  These are "inline scope branches"
+     * whose child key definitions must be processed under the child scope prefix.
+     *
+     * Only top-level blocks are returned; nested ones are found recursively in
+     * processInlineScopeBlocks so they are never double-processed.
+     */
+    private extractInlineScopeBlocks(content: string): Array<{
+        keyscopes: string[];
+        inlineKeys: string[];
+        innerContent: string;
+        outerStart: number;
+        outerEnd: number;
+    }> {
+        const blocks: Array<{
+            keyscopes: string[];
+            inlineKeys: string[];
+            innerContent: string;
+            outerStart: number;
+            outerEnd: number;
+        }> = [];
+
+        const keyscopedRe = new RegExp(
+            `<(\\w+)\\b${TAG_ATTRS}\\bkeyscope\\s*=\\s*["']([^"']+)["']${TAG_ATTRS}>`,
+            'gi'
+        );
+
+        let match: RegExpExecArray | null;
+        while ((match = keyscopedRe.exec(content)) !== null) {
+            const fullOpenTag = match[0];
+            const elemName = match[1];
+
+            // Root map/bookmap keyscopes are handled by extractRootKeyscope
+            if (/^(?:map|bookmap)$/i.test(elemName)) continue;
+            // Submap references are handled by extractMapReferences + inlineKeys mechanism
+            if (/\bhref\s*=\s*["'][^"']*\.(?:ditamap|bookmap)["']/i.test(fullOpenTag)) continue;
+            // Self-closing elements have no children to scope
+            if (fullOpenTag.endsWith('/>')) continue;
+
+            const openTagEnd = match.index + fullOpenTag.length;
+            const inner = this.findInnerContent(content, openTagEnd, elemName);
+            if (!inner) continue;
+
+            const keyscopes = match[2].split(/\s+/).filter(s => s.length > 0);
+            const keysMatch = fullOpenTag.match(/\bkeys\s*=\s*["']([^"']+)["']/i);
+            const inlineKeys = keysMatch
+                ? keysMatch[1].split(/\s+/).filter(k => k.length > 0)
+                : [];
+
+            blocks.push({
+                keyscopes,
+                inlineKeys,
+                innerContent: inner.content,
+                outerStart: match.index,
+                outerEnd: inner.end,
+            });
+        }
+
+        // Keep only top-level blocks; nested blocks are handled by recursion.
+        return blocks.filter(block =>
+            !blocks.some(
+                other =>
+                    other !== block &&
+                    other.outerStart < block.outerStart &&
+                    block.outerEnd <= other.outerEnd
+            )
+        );
+    }
+
+    /**
+     * Given a position immediately after an element's opening tag, find the matching
+     * closing tag and return the inner content and the end position of the close tag.
+     * Handles nesting of same-name elements correctly via a depth counter.
+     */
+    private findInnerContent(
+        content: string,
+        fromIndex: number,
+        tagName: string
+    ): { content: string; end: number } | null {
+        const escapedTag = tagName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        const openRe = new RegExp(`<${escapedTag}\\b`, 'gi');
+        const closeRe = new RegExp(`<\\/${escapedTag}\\s*>`, 'gi');
+
+        let depth = 1;
+        let pos = fromIndex;
+
+        while (depth > 0 && pos < content.length) {
+            openRe.lastIndex = pos;
+            closeRe.lastIndex = pos;
+            const nextOpen = openRe.exec(content);
+            const nextClose = closeRe.exec(content);
+
+            if (!nextClose) return null; // Malformed XML
+
+            if (nextOpen && nextOpen.index < nextClose.index) {
+                depth++;
+                pos = nextOpen.index + nextOpen[0].length;
+            } else {
+                depth--;
+                if (depth === 0) {
+                    return {
+                        content: content.substring(fromIndex, nextClose.index),
+                        end: nextClose.index + nextClose[0].length,
+                    };
+                }
+                pos = nextClose.index + nextClose[0].length;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Replace character ranges with spaces to prevent re-processing.
+     * Preserves string length so that regex lastIndex values in the original
+     * content remain valid after masking.
+     */
+    private maskRanges(
+        content: string,
+        ranges: Array<{ start: number; end: number }>
+    ): string {
+        if (ranges.length === 0) return content;
+        const sorted = [...ranges].sort((a, b) => a.start - b.start);
+        let result = '';
+        let pos = 0;
+        for (const { start, end } of sorted) {
+            if (start > pos) result += content.substring(pos, start);
+            result += ' '.repeat(Math.max(0, end - start));
+            pos = end;
+        }
+        result += content.substring(pos);
+        return result;
+    }
+
+    /**
+     * Recursively process inline scope branches within map content.
+     *
+     * For each top-level element with @keyscope (but no external map href):
+     *   1. Compute child scope prefixes.
+     *   2. Register any @keys on the scope element itself in the child scope.
+     *   3. Recurse into the block's inner content (handles nesting).
+     *   4. Extract key definitions and topic references from the inner content
+     *      and register them under child scope prefixes.
+     *   5. Discover submaps inside the block and push them onto bfsQueue with
+     *      the appropriate child scope prefixes.
+     *
+     * Returns the input content with all inline scope block ranges replaced by
+     * spaces so the caller's extractKeyDefinitions / extractTopicReferences /
+     * extractMapReferences calls do not double-count child-scope content.
+     */
+    private processInlineScopeBlocks(
+        content: string,
+        mapPath: string,
+        parentEffectivePrefixes: string[],
+        keySpace: KeySpace,
+        scopeDirectKeys: Map<string, KeyDefinition[]>,
+        bfsQueue: Array<{ mapPath: string; scopePrefixes: string[] }>,
+        maxLinkMatches: number,
+        depth = 0
+    ): string {
+        if (depth > MAX_INLINE_SCOPE_DEPTH) return content;
+
+        const blocks = this.extractInlineScopeBlocks(content);
+        if (blocks.length === 0) return content;
+
+        const maskedContent = this.maskRanges(
+            content,
+            blocks.map(b => ({ start: b.outerStart, end: b.outerEnd }))
+        );
+
+        for (const block of blocks) {
+            const childPrefixes = this.combineScopePrefixes(parentEffectivePrefixes, block.keyscopes);
+            if (childPrefixes.length === 0) continue;
+
+            for (const prefix of childPrefixes) {
+                if (!scopeDirectKeys.has(prefix)) scopeDirectKeys.set(prefix, []);
+            }
+
+            // @keys on the scope-creating element itself belong to the child scope (DITA §2.4.4.1)
+            for (const inlineKeyName of block.inlineKeys) {
+                const inlineDef: KeyDefinition = { keyName: inlineKeyName, sourceMap: mapPath };
+                for (const prefix of childPrefixes) {
+                    const directKeys = scopeDirectKeys.get(prefix)!;
+                    if (!directKeys.some(k => k.keyName === inlineKeyName)) directKeys.push(inlineDef);
+                    const qualifiedName = `${prefix}.${inlineKeyName}`;
+                    if (!keySpace.keys.has(qualifiedName)) {
+                        keySpace.keys.set(qualifiedName, { ...inlineDef, keyName: qualifiedName });
+                    }
+                }
+                if (!keySpace.keys.has(inlineKeyName)) keySpace.keys.set(inlineKeyName, inlineDef);
+            }
+
+            // Recurse into nested inline scopes; receive inner content with those sub-blocks masked
+            const maskedBlockContent = this.processInlineScopeBlocks(
+                block.innerContent, mapPath, childPrefixes,
+                keySpace, scopeDirectKeys, bfsQueue, maxLinkMatches, depth + 1
+            );
+
+            // Register key definitions from the (masked) block content under child scope
+            const blockKeys = this.extractKeyDefinitions(maskedBlockContent, mapPath, maxLinkMatches);
+            for (const keyDef of blockKeys) {
+                for (const prefix of childPrefixes) {
+                    const directKeys = scopeDirectKeys.get(prefix)!;
+                    if (!directKeys.some(k => k.keyName === keyDef.keyName)) directKeys.push(keyDef);
+                    const qualifiedName = `${prefix}.${keyDef.keyName}`;
+                    if (!keySpace.keys.has(qualifiedName)) {
+                        keySpace.keys.set(qualifiedName, { ...keyDef, keyName: qualifiedName });
+                    }
+                }
+                if (!keySpace.keys.has(keyDef.keyName)) {
+                    keySpace.keys.set(keyDef.keyName, keyDef);
+                } else {
+                    let dups = keySpace.duplicateKeys.get(keyDef.keyName);
+                    if (!dups) {
+                        dups = [keySpace.keys.get(keyDef.keyName)!, keyDef];
+                        keySpace.duplicateKeys.set(keyDef.keyName, dups);
+                    } else {
+                        dups.push(keyDef);
+                    }
+                }
+            }
+
+            // Register topic-scope associations for context-aware resolution
+            this.extractTopicReferences(
+                maskedBlockContent, mapPath, childPrefixes[0], keySpace.topicToScope, maxLinkMatches
+            );
+
+            // Discover submaps inside this block and queue with combined scope prefix
+            const blockSubmaps = this.extractMapReferences(maskedBlockContent, mapPath, maxLinkMatches);
+            for (const submap of blockSubmaps) {
+                const grandchildPrefixes = this.combineScopePrefixes(childPrefixes, submap.keyscopes);
+                if (submap.inlineKeys.length > 0 && grandchildPrefixes.length > 0) {
+                    for (const inlineKeyName of submap.inlineKeys) {
+                        const inlineDef: KeyDefinition = {
+                            keyName: inlineKeyName,
+                            sourceMap: mapPath,
+                            targetFile: submap.path,
+                        };
+                        for (const prefix of grandchildPrefixes) {
+                            if (!scopeDirectKeys.has(prefix)) scopeDirectKeys.set(prefix, []);
+                            const directKeys = scopeDirectKeys.get(prefix)!;
+                            if (!directKeys.some(k => k.keyName === inlineKeyName)) directKeys.push(inlineDef);
+                            const qualifiedName = `${prefix}.${inlineKeyName}`;
+                            if (!keySpace.keys.has(qualifiedName)) {
+                                keySpace.keys.set(qualifiedName, { ...inlineDef, keyName: qualifiedName });
+                            }
+                        }
+                        if (!keySpace.keys.has(inlineKeyName)) keySpace.keys.set(inlineKeyName, inlineDef);
+                    }
+                }
+                bfsQueue.push({ mapPath: submap.path, scopePrefixes: grandchildPrefixes });
+            }
+        }
+
+        return maskedContent;
     }
 
     /**

--- a/server/src/services/keySpaceService.ts
+++ b/server/src/services/keySpaceService.ts
@@ -425,7 +425,9 @@ export class KeySpaceService implements IKeySpaceService {
 
             try {
                 const rawContent = await fsPromises.readFile(currentMap, 'utf-8');
-                const mapContent = stripCommentsAndCDATA(rawContent);
+                // Strip comments/CDATA first, then reltable blocks.
+                // reltable hrefs are relationship-table links — not key-space content (spec §2.4.4).
+                const mapContent = this.stripReltables(stripCommentsAndCDATA(rawContent));
 
                 const rootScopes = this.extractRootKeyscope(mapContent);
                 const effectivePrefixes = this.combineScopePrefixes(scopePrefixes, rootScopes);
@@ -485,6 +487,35 @@ export class KeySpaceService implements IKeySpaceService {
                 const submaps = this.extractMapReferences(mapContent, currentMap, maxLinkMatches);
                 for (const submap of submaps) {
                     const childPrefixes = this.combineScopePrefixes(effectivePrefixes, submap.keyscopes);
+
+                    // Register @keys defined on the mapref element itself under the child scope prefix.
+                    // The mapref element is included in the child scope it creates (DITA spec §2.4.4.1).
+                    if (submap.inlineKeys.length > 0 && childPrefixes.length > 0) {
+                        for (const inlineKeyName of submap.inlineKeys) {
+                            const inlineDef: KeyDefinition = {
+                                keyName: inlineKeyName,
+                                sourceMap: currentMap,
+                                targetFile: submap.path,
+                            };
+                            for (const prefix of childPrefixes) {
+                                if (!scopeDirectKeys.has(prefix)) {
+                                    scopeDirectKeys.set(prefix, []);
+                                }
+                                const directKeys = scopeDirectKeys.get(prefix)!;
+                                if (!directKeys.some(k => k.keyName === inlineKeyName)) {
+                                    directKeys.push(inlineDef);
+                                }
+                                const qualifiedName = `${prefix}.${inlineKeyName}`;
+                                if (!keySpace.keys.has(qualifiedName)) {
+                                    keySpace.keys.set(qualifiedName, { ...inlineDef, keyName: qualifiedName });
+                                }
+                            }
+                            if (!keySpace.keys.has(inlineKeyName)) {
+                                keySpace.keys.set(inlineKeyName, inlineDef);
+                            }
+                        }
+                    }
+
                     queue.push({ mapPath: submap.path, scopePrefixes: childPrefixes });
                 }
             } catch {
@@ -536,6 +567,14 @@ export class KeySpaceService implements IKeySpaceService {
 
             const keysValue = match[2];
             const fullElement = match[0];
+
+            // Skip elements that carry @keyscope AND reference a submap file.
+            // Their @keys belong to the child scope and are registered by the BFS
+            // submap loop (via extractMapReferences inlineKeys), not here.
+            const hasKeyscope = /\bkeyscope\s*=\s*["'][^"']+["']/i.test(fullElement);
+            const hasMapHref = /\bhref\s*=\s*["'][^"']*\.(?:ditamap|bookmap)["']/i.test(fullElement);
+            if (hasKeyscope && hasMapHref) continue;
+
             const keyNames = keysValue.split(/\s+/).filter(k => k.length > 0);
 
             for (const keyName of keyNames) {
@@ -737,8 +776,8 @@ export class KeySpaceService implements IKeySpaceService {
         mapContent: string,
         mapPath: string,
         maxLinkMatches: number
-    ): { path: string; keyscopes: string[] }[] {
-        const submaps: { path: string; keyscopes: string[] }[] = [];
+    ): { path: string; keyscopes: string[]; inlineKeys: string[] }[] {
+        const submaps: { path: string; keyscopes: string[]; inlineKeys: string[] }[] = [];
         const mapDir = path.dirname(mapPath);
         // Match ANY element with href pointing to a .ditamap or .bookmap file.
         // This covers mapref, topicref, chapter, appendix, part, glossarylist,
@@ -763,7 +802,15 @@ export class KeySpaceService implements IKeySpaceService {
                 const keyscopes = keyscopeMatch
                     ? keyscopeMatch[1].split(/\s+/).filter(s => s.length > 0)
                     : [];
-                submaps.push({ path: absolutePath, keyscopes });
+                // Capture @keys on the mapref element itself when @keyscope is also present.
+                // Per DITA spec, @keys on the same element as @keyscope belong to the child scope.
+                const keysMatch = keyscopes.length > 0
+                    ? match[0].match(/\bkeys\s*=\s*["']([^"']+)["']/i)
+                    : null;
+                const inlineKeys = keysMatch
+                    ? keysMatch[1].split(/\s+/).filter(k => k.length > 0)
+                    : [];
+                submaps.push({ path: absolutePath, keyscopes, inlineKeys });
             }
         }
 
@@ -874,6 +921,15 @@ export class KeySpaceService implements IKeySpaceService {
             }
         }
         return Array.from(combined);
+    }
+
+    /**
+     * Remove `<reltable>` blocks from map content before key-space extraction.
+     * Relationship tables define topic relationships, not key definitions; their
+     * hrefs must not pollute scopeDirectKeys or topicToScope (DITA spec §2.4.4).
+     */
+    private stripReltables(content: string): string {
+        return content.replace(/<reltable\b[^>]*>[\s\S]*?<\/reltable\s*>/gi, '');
     }
 
     /** Extract keyscope(s) from the root map/bookmap element. */

--- a/server/test/keySpaceService.test.ts
+++ b/server/test/keySpaceService.test.ts
@@ -636,6 +636,52 @@ suite('KeySpaceService', () => {
                 cleanup(tmpDir);
             }
         });
+
+        test('multi-name keyscope: PushDown works for every scope alias', async () => {
+            // Regression for Bug 1: when keyscope="a b", scopeDirectKeys must be
+            // initialised for both 'a' and 'b' so that child scopes of either alias
+            // inherit ancestor keys correctly.
+            const tmpDir = makeTmpDir();
+            const service = createService(tmpDir);
+            try {
+                const rootPath = path.join(tmpDir, 'root.ditamap');
+                fs.writeFileSync(rootPath, `<?xml version="1.0"?>
+<map>
+  <keydef keys="logo" href="logo.dita"/>
+  <mapref href="lib.ditamap" keyscope="libA libB"/>
+</map>`, 'utf-8');
+
+                const subPath = path.join(tmpDir, 'lib.ditamap');
+                fs.writeFileSync(subPath, `<?xml version="1.0"?>
+<map>
+  <keydef keys="api" href="api.dita"/>
+  <mapref href="deep.ditamap" keyscope="core"/>
+</map>`, 'utf-8');
+
+                const deepPath = path.join(tmpDir, 'deep.ditamap');
+                fs.writeFileSync(deepPath, `<?xml version="1.0"?>
+<map>
+  <keydef keys="util" href="util.dita"/>
+</map>`, 'utf-8');
+
+                const keySpace = await service.buildKeySpace(rootPath);
+
+                // Both scope aliases should get PushDown-inherited ancestor keys
+                assert.ok(keySpace.keys.has('libA.logo'),
+                    'PushDown: root logo should appear under libA alias');
+                assert.ok(keySpace.keys.has('libB.logo'),
+                    'PushDown: root logo should appear under libB alias');
+
+                // Deep child under libA must also inherit logo from root
+                assert.ok(keySpace.keys.has('libA.core.logo'),
+                    'PushDown: root logo should propagate into libA.core namespace');
+                assert.ok(keySpace.keys.has('libB.core.logo'),
+                    'PushDown: root logo should propagate into libB.core namespace');
+            } finally {
+                service.shutdown();
+                cleanup(tmpDir);
+            }
+        });
     });
 
     suite('context-aware key resolution', () => {

--- a/server/test/keySpaceService.test.ts
+++ b/server/test/keySpaceService.test.ts
@@ -762,4 +762,135 @@ suite('KeySpaceService', () => {
             }
         });
     });
+
+    suite('reltable exclusion', () => {
+
+        test('keys inside reltable are not extracted', async () => {
+            const tmpDir = makeTmpDir();
+            const service = createService(tmpDir);
+            try {
+                const mapPath = path.join(tmpDir, 'root.ditamap');
+                fs.writeFileSync(mapPath, `<?xml version="1.0"?>
+<map>
+  <keydef keys="real" href="real.dita"/>
+  <reltable>
+    <relrow>
+      <relcell><topicref keys="ghost" href="ghost.dita"/></relcell>
+    </relrow>
+  </reltable>
+</map>`, 'utf-8');
+
+                const keySpace = await service.buildKeySpace(mapPath);
+                assert.ok(keySpace.keys.has('real'), 'normal keydef should be extracted');
+                assert.ok(!keySpace.keys.has('ghost'), 'keys inside reltable must not be extracted');
+            } finally {
+                service.shutdown();
+                cleanup(tmpDir);
+            }
+        });
+
+        test('hrefs inside reltable do not pollute topicToScope', async () => {
+            const tmpDir = makeTmpDir();
+            const service = createService(tmpDir);
+            try {
+                const rootPath = path.join(tmpDir, 'root.ditamap');
+                fs.writeFileSync(rootPath, `<?xml version="1.0"?>
+<map>
+  <mapref href="child.ditamap" keyscope="child"/>
+  <reltable>
+    <relrow>
+      <relcell><topicref href="guide.dita"/></relcell>
+    </relrow>
+  </reltable>
+</map>`, 'utf-8');
+
+                const childPath = path.join(tmpDir, 'child.ditamap');
+                fs.writeFileSync(childPath, `<?xml version="1.0"?>
+<map>
+  <topicref href="guide.dita"/>
+</map>`, 'utf-8');
+
+                const guidePath = path.join(tmpDir, 'guide.dita');
+                fs.writeFileSync(guidePath, '', 'utf-8');
+
+                const keySpace = await service.buildKeySpace(rootPath);
+                // guide.dita is referenced in the root reltable AND in child scope.
+                // The reltable reference (root scope) must NOT win — guide.dita belongs to child scope.
+                const scopePrefix = keySpace.topicToScope.get(path.normalize(guidePath));
+                assert.strictEqual(scopePrefix, 'child',
+                    'reltable href must not claim scope — child scope topicref should win');
+            } finally {
+                service.shutdown();
+                cleanup(tmpDir);
+            }
+        });
+    });
+
+    suite('@keys on keyscoped mapref elements', () => {
+
+        test('@keys on mapref with @keyscope registers key in child scope', async () => {
+            const tmpDir = makeTmpDir();
+            const service = createService(tmpDir);
+            try {
+                const rootPath = path.join(tmpDir, 'root.ditamap');
+                fs.writeFileSync(rootPath, `<?xml version="1.0"?>
+<map>
+  <mapref keyscope="product" keys="product-map" href="product.ditamap"/>
+</map>`, 'utf-8');
+
+                const subPath = path.join(tmpDir, 'product.ditamap');
+                fs.writeFileSync(subPath, `<?xml version="1.0"?>
+<map>
+  <keydef keys="widget" href="widget.dita"/>
+</map>`, 'utf-8');
+
+                const keySpace = await service.buildKeySpace(rootPath);
+                // product-map is defined on the mapref itself, which carries @keyscope="product"
+                // Per DITA spec, it belongs to the product scope.
+                assert.ok(keySpace.keys.has('product-map'),
+                    'inline key from keyscoped mapref should exist (unqualified fallback)');
+                assert.ok(keySpace.keys.has('product.product-map'),
+                    'inline key must be registered under child scope qualified name');
+                assert.ok(
+                    keySpace.keys.get('product.product-map')!.targetFile?.endsWith('product.ditamap'),
+                    'child-scope inline key should target the referenced submap'
+                );
+            } finally {
+                service.shutdown();
+                cleanup(tmpDir);
+            }
+        });
+
+        test('@keys on mapref with @keyscope not duplicated in parent scope direct keys', async () => {
+            const tmpDir = makeTmpDir();
+            const service = createService(tmpDir);
+            try {
+                const rootPath = path.join(tmpDir, 'root.ditamap');
+                fs.writeFileSync(rootPath, `<?xml version="1.0"?>
+<map>
+  <keydef keys="shared" href="root-shared.dita"/>
+  <mapref keyscope="sub" keys="shared" href="sub.ditamap"/>
+</map>`, 'utf-8');
+
+                const subPath = path.join(tmpDir, 'sub.ditamap');
+                fs.writeFileSync(subPath, `<?xml version="1.0"?>
+<map>
+  <keydef keys="api" href="api.dita"/>
+</map>`, 'utf-8');
+
+                const keySpace = await service.buildKeySpace(rootPath);
+                // The root map has keydef keys="shared" → root scope wins for unqualified 'shared'
+                assert.ok(
+                    keySpace.keys.get('shared')!.targetFile?.endsWith('root-shared.dita'),
+                    'root keydef should win for unqualified shared'
+                );
+                // sub.shared should target the submap (the inline key from the mapref)
+                assert.ok(keySpace.keys.has('sub.shared'),
+                    'inline key should also exist as sub.shared');
+            } finally {
+                service.shutdown();
+                cleanup(tmpDir);
+            }
+        });
+    });
 });

--- a/server/test/keySpaceService.test.ts
+++ b/server/test/keySpaceService.test.ts
@@ -413,4 +413,307 @@ suite('KeySpaceService', () => {
             }
         });
     });
+
+    suite('keyref chain resolution', () => {
+
+        test('keyref attribute is captured on KeyDefinition', async () => {
+            const tmpDir = makeTmpDir();
+            const service = createService(tmpDir);
+            try {
+                const mapPath = path.join(tmpDir, 'root.ditamap');
+                fs.writeFileSync(mapPath, `<?xml version="1.0"?>
+<map>
+  <keydef keys="alias" keyref="real"/>
+  <keydef keys="real" href="real.dita"/>
+</map>`, 'utf-8');
+
+                const keySpace = await service.buildKeySpace(mapPath);
+                const aliasDef = keySpace.keys.get('alias');
+                assert.ok(aliasDef, 'alias key should exist');
+                assert.strictEqual(aliasDef!.keyref, 'real', 'keyref attribute should be captured');
+            } finally {
+                service.shutdown();
+                cleanup(tmpDir);
+            }
+        });
+
+        test('resolveKey follows keyref chain to final definition', async () => {
+            const tmpDir = makeTmpDir();
+            const service = createService(tmpDir);
+            try {
+                const mapPath = path.join(tmpDir, 'root.ditamap');
+                fs.writeFileSync(mapPath, `<?xml version="1.0"?>
+<map>
+  <keydef keys="alias" keyref="real"/>
+  <keydef keys="real" href="real.dita"/>
+</map>`, 'utf-8');
+
+                const contextFile = path.join(tmpDir, 'topic.dita');
+                fs.writeFileSync(contextFile, '', 'utf-8');
+
+                const result = await service.resolveKey('alias', contextFile);
+                assert.ok(result, 'alias key should resolve');
+                assert.ok(result!.targetFile?.endsWith('real.dita'),
+                    'resolved definition should point to real.dita, not alias');
+            } finally {
+                service.shutdown();
+                cleanup(tmpDir);
+            }
+        });
+
+        test('multi-hop keyref chain resolves transitively', async () => {
+            const tmpDir = makeTmpDir();
+            const service = createService(tmpDir);
+            try {
+                const mapPath = path.join(tmpDir, 'root.ditamap');
+                fs.writeFileSync(mapPath, `<?xml version="1.0"?>
+<map>
+  <keydef keys="a" keyref="b"/>
+  <keydef keys="b" keyref="c"/>
+  <keydef keys="c" href="final.dita"/>
+</map>`, 'utf-8');
+
+                const contextFile = path.join(tmpDir, 'topic.dita');
+                fs.writeFileSync(contextFile, '', 'utf-8');
+
+                const result = await service.resolveKey('a', contextFile);
+                assert.ok(result, 'multi-hop keyref should resolve');
+                assert.ok(result!.targetFile?.endsWith('final.dita'),
+                    'should resolve through full chain to final.dita');
+            } finally {
+                service.shutdown();
+                cleanup(tmpDir);
+            }
+        });
+
+        test('cyclic keyref does not hang — returns a definition', async () => {
+            const tmpDir = makeTmpDir();
+            const service = createService(tmpDir);
+            try {
+                const mapPath = path.join(tmpDir, 'root.ditamap');
+                fs.writeFileSync(mapPath, `<?xml version="1.0"?>
+<map>
+  <keydef keys="x" keyref="y"/>
+  <keydef keys="y" keyref="x"/>
+</map>`, 'utf-8');
+
+                const contextFile = path.join(tmpDir, 'topic.dita');
+                fs.writeFileSync(contextFile, '', 'utf-8');
+
+                // Must not throw or hang; result may be x or y but must be non-null
+                const result = await service.resolveKey('x', contextFile);
+                assert.ok(result, 'cyclic keyref should return a definition, not null');
+            } finally {
+                service.shutdown();
+                cleanup(tmpDir);
+            }
+        });
+
+        test('keyref to missing key returns the alias definition itself', async () => {
+            const tmpDir = makeTmpDir();
+            const service = createService(tmpDir);
+            try {
+                const mapPath = path.join(tmpDir, 'root.ditamap');
+                fs.writeFileSync(mapPath, `<?xml version="1.0"?>
+<map>
+  <keydef keys="alias" keyref="nonexistent"/>
+</map>`, 'utf-8');
+
+                const contextFile = path.join(tmpDir, 'topic.dita');
+                fs.writeFileSync(contextFile, '', 'utf-8');
+
+                const result = await service.resolveKey('alias', contextFile);
+                assert.ok(result, 'alias with broken chain should still return a definition');
+                assert.strictEqual(result!.keyName, 'alias',
+                    'broken chain returns the alias definition itself');
+            } finally {
+                service.shutdown();
+                cleanup(tmpDir);
+            }
+        });
+    });
+
+    suite('PushDown scope inheritance', () => {
+
+        test('ancestor key is accessible via child-scope qualified name', async () => {
+            const tmpDir = makeTmpDir();
+            const service = createService(tmpDir);
+            try {
+                const rootPath = path.join(tmpDir, 'root.ditamap');
+                fs.writeFileSync(rootPath, `<?xml version="1.0"?>
+<map>
+  <keydef keys="logo" href="logo.dita"/>
+  <mapref href="lib.ditamap" keyscope="lib"/>
+</map>`, 'utf-8');
+
+                const subPath = path.join(tmpDir, 'lib.ditamap');
+                fs.writeFileSync(subPath, `<?xml version="1.0"?>
+<map>
+  <keydef keys="api" href="api.dita"/>
+</map>`, 'utf-8');
+
+                const keySpace = await service.buildKeySpace(rootPath);
+                assert.ok(keySpace.keys.has('logo'), 'unqualified ancestor key should exist');
+                assert.ok(keySpace.keys.has('lib.api'), 'child scope key should exist');
+                assert.ok(keySpace.keys.has('lib.logo'),
+                    'PushDown should make ancestor key available as lib.logo');
+                assert.ok(
+                    keySpace.keys.get('lib.logo')!.targetFile?.endsWith('logo.dita'),
+                    'inherited lib.logo should point to logo.dita'
+                );
+            } finally {
+                service.shutdown();
+                cleanup(tmpDir);
+            }
+        });
+
+        test('child-scope override wins over ancestor key in qualified namespace', async () => {
+            const tmpDir = makeTmpDir();
+            const service = createService(tmpDir);
+            try {
+                const rootPath = path.join(tmpDir, 'root.ditamap');
+                fs.writeFileSync(rootPath, `<?xml version="1.0"?>
+<map>
+  <keydef keys="version" href="v1.dita"/>
+  <mapref href="product.ditamap" keyscope="product"/>
+</map>`, 'utf-8');
+
+                const subPath = path.join(tmpDir, 'product.ditamap');
+                fs.writeFileSync(subPath, `<?xml version="1.0"?>
+<map>
+  <keydef keys="version" href="v2.dita"/>
+</map>`, 'utf-8');
+
+                const keySpace = await service.buildKeySpace(rootPath);
+                // product.version should be the child scope's definition (v2), not the root's (v1)
+                const productVersion = keySpace.keys.get('product.version');
+                assert.ok(productVersion, 'product.version should exist');
+                assert.ok(
+                    productVersion!.targetFile?.endsWith('v2.dita'),
+                    'child-scope override should win for product.version'
+                );
+            } finally {
+                service.shutdown();
+                cleanup(tmpDir);
+            }
+        });
+
+        test('deeply nested scope inherits from all ancestors', async () => {
+            const tmpDir = makeTmpDir();
+            const service = createService(tmpDir);
+            try {
+                const rootPath = path.join(tmpDir, 'root.ditamap');
+                fs.writeFileSync(rootPath, `<?xml version="1.0"?>
+<map>
+  <keydef keys="brand" href="brand.dita"/>
+  <mapref href="product.ditamap" keyscope="product"/>
+</map>`, 'utf-8');
+
+                const midPath = path.join(tmpDir, 'product.ditamap');
+                fs.writeFileSync(midPath, `<?xml version="1.0"?>
+<map>
+  <keydef keys="version" href="v1.dita"/>
+  <mapref href="module.ditamap" keyscope="module"/>
+</map>`, 'utf-8');
+
+                const leafPath = path.join(tmpDir, 'module.ditamap');
+                fs.writeFileSync(leafPath, `<?xml version="1.0"?>
+<map>
+  <keydef keys="api" href="api.dita"/>
+</map>`, 'utf-8');
+
+                const keySpace = await service.buildKeySpace(rootPath);
+                // product.module.api — direct key
+                assert.ok(keySpace.keys.has('product.module.api'), 'direct leaf key should exist');
+                // product.module.version — inherited from product scope via PushDown
+                assert.ok(keySpace.keys.has('product.module.version'),
+                    'PushDown should inherit product.version into product.module namespace');
+                // product.module.brand — inherited from root scope via PushDown
+                assert.ok(keySpace.keys.has('product.module.brand'),
+                    'PushDown should inherit root brand into product.module namespace');
+            } finally {
+                service.shutdown();
+                cleanup(tmpDir);
+            }
+        });
+    });
+
+    suite('context-aware key resolution', () => {
+
+        test('resolveKey uses child-scope definition when context is in that scope', async () => {
+            const tmpDir = makeTmpDir();
+            const service = createService(tmpDir);
+            try {
+                const rootPath = path.join(tmpDir, 'root.ditamap');
+                fs.writeFileSync(rootPath, `<?xml version="1.0"?>
+<map>
+  <keydef keys="version" href="v1.dita"/>
+  <mapref href="product.ditamap" keyscope="product"/>
+</map>`, 'utf-8');
+
+                const subPath = path.join(tmpDir, 'product.ditamap');
+                fs.writeFileSync(subPath, `<?xml version="1.0"?>
+<map>
+  <keydef keys="version" href="v2.dita"/>
+  <topicref href="product-guide.dita"/>
+</map>`, 'utf-8');
+
+                // product-guide.dita is within the "product" scope
+                const productGuide = path.join(tmpDir, 'product-guide.dita');
+                fs.writeFileSync(productGuide, '', 'utf-8');
+
+                // A topic outside any named scope
+                const rootTopic = path.join(tmpDir, 'root-topic.dita');
+                fs.writeFileSync(rootTopic, '', 'utf-8');
+
+                // From product-guide (product scope) → should get v2
+                const fromProduct = await service.resolveKey('version', productGuide);
+                assert.ok(fromProduct, 'version should resolve from product-guide context');
+                assert.ok(
+                    fromProduct!.targetFile?.endsWith('v2.dita'),
+                    'context-aware resolution should return product scope version (v2)'
+                );
+
+                // From root-topic (no named scope) → should get v1
+                const fromRoot = await service.resolveKey('version', rootTopic);
+                assert.ok(fromRoot, 'version should resolve from root-topic context');
+                assert.ok(
+                    fromRoot!.targetFile?.endsWith('v1.dita'),
+                    'context-free resolution should return root scope version (v1)'
+                );
+            } finally {
+                service.shutdown();
+                cleanup(tmpDir);
+            }
+        });
+
+        test('topicToScope maps topic to its owning scope prefix', async () => {
+            const tmpDir = makeTmpDir();
+            const service = createService(tmpDir);
+            try {
+                const rootPath = path.join(tmpDir, 'root.ditamap');
+                fs.writeFileSync(rootPath, `<?xml version="1.0"?>
+<map>
+  <mapref href="lib.ditamap" keyscope="lib"/>
+</map>`, 'utf-8');
+
+                const subPath = path.join(tmpDir, 'lib.ditamap');
+                fs.writeFileSync(subPath, `<?xml version="1.0"?>
+<map>
+  <topicref href="lib-guide.dita"/>
+</map>`, 'utf-8');
+
+                const guidePath = path.join(tmpDir, 'lib-guide.dita');
+                fs.writeFileSync(guidePath, '', 'utf-8');
+
+                const keySpace = await service.buildKeySpace(rootPath);
+                const scopePrefix = keySpace.topicToScope.get(path.normalize(guidePath));
+                assert.strictEqual(scopePrefix, 'lib',
+                    'lib-guide.dita should be recorded in the "lib" scope');
+            } finally {
+                service.shutdown();
+                cleanup(tmpDir);
+            }
+        });
+    });
 });

--- a/server/test/keySpaceService.test.ts
+++ b/server/test/keySpaceService.test.ts
@@ -2,7 +2,7 @@ import * as assert from 'assert';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
-import { KeySpaceService } from '../src/services/keySpaceService';
+import { KeySpaceService, formatResolutionReport, reportKeySpace } from '../src/services/keySpaceService';
 
 function makeTmpDir(): string {
     return fs.mkdtempSync(path.join(os.tmpdir(), 'ditacraft-test-'));
@@ -1080,6 +1080,977 @@ suite('KeySpaceService', () => {
                 // inner.ditamap should be processed as "outer.inner" scope
                 assert.ok(keySpace.keys.has('outer.inner.lib'),
                     'submap inside inline scope should get compound prefix outer.inner.lib');
+            } finally {
+                service.shutdown();
+                cleanup(tmpDir);
+            }
+        });
+    });
+
+    suite('provenance tracking (Gap 6)', () => {
+
+        test('sourceLine is set on keys extracted via regex fallback path', async () => {
+            // Force regex path by writing malformed XML (no closing </map>).
+            const tmpDir = makeTmpDir();
+            const service = createService(tmpDir);
+            try {
+                const mapPath = path.join(tmpDir, 'root.ditamap');
+                // Line 1: <?xml...>, line 2: <map>, line 3: <keydef keys=.../>
+                fs.writeFileSync(mapPath,
+                    `<?xml version="1.0"?>\n<map>\n  <keydef keys="first" href="a.dita"/>`, 'utf-8');
+
+                const keySpace = await service.buildKeySpace(mapPath);
+                const def = keySpace.keys.get('first');
+                assert.ok(def, 'key "first" should be registered');
+                assert.ok(typeof def!.sourceLine === 'number' && def!.sourceLine >= 1,
+                    'sourceLine should be a positive integer');
+                assert.strictEqual(def!.sourceLine, 3,
+                    'keydef on line 3 should have sourceLine=3');
+            } finally {
+                service.shutdown();
+                cleanup(tmpDir);
+            }
+        });
+
+        test('sourceLine is set on keys extracted via XML parser path', async () => {
+            const tmpDir = makeTmpDir();
+            const service = createService(tmpDir);
+            try {
+                const mapPath = path.join(tmpDir, 'root.ditamap');
+                fs.writeFileSync(mapPath, `<?xml version="1.0"?>
+<map>
+  <keydef keys="line3key" href="a.dita"/>
+  <keydef keys="line4key" href="b.dita"/>
+</map>`, 'utf-8');
+
+                const keySpace = await service.buildKeySpace(mapPath);
+                const def3 = keySpace.keys.get('line3key');
+                const def4 = keySpace.keys.get('line4key');
+                assert.ok(def3 && typeof def3.sourceLine === 'number',
+                    'line3key should have sourceLine');
+                assert.ok(def4 && typeof def4.sourceLine === 'number',
+                    'line4key should have sourceLine');
+                assert.ok(def3!.sourceLine! < def4!.sourceLine!,
+                    'line3key sourceLine must be less than line4key sourceLine (document order)');
+            } finally {
+                service.shutdown();
+                cleanup(tmpDir);
+            }
+        });
+
+        test('duplicate keys report different sourceLines', async () => {
+            const tmpDir = makeTmpDir();
+            const service = createService(tmpDir);
+            try {
+                const mapPath = path.join(tmpDir, 'root.ditamap');
+                fs.writeFileSync(mapPath, `<?xml version="1.0"?>
+<map>
+  <keydef keys="shared" href="first.dita"/>
+  <keydef keys="other" href="other.dita"/>
+  <keydef keys="shared" href="second.dita"/>
+</map>`, 'utf-8');
+
+                const keySpace = await service.buildKeySpace(mapPath);
+                const dups = keySpace.duplicateKeys.get('shared');
+                assert.ok(dups && dups.length >= 2,
+                    'shared key should be recorded as duplicate');
+                const lines = dups!.map(d => d.sourceLine).filter(l => l !== undefined);
+                assert.ok(lines.length >= 2, 'both duplicate definitions should carry sourceLine');
+                assert.notStrictEqual(lines[0], lines[1],
+                    'duplicate definitions should report different source lines');
+            } finally {
+                service.shutdown();
+                cleanup(tmpDir);
+            }
+        });
+
+        test('qualified scope alias inherits sourceLine from original definition', async () => {
+            const tmpDir = makeTmpDir();
+            const service = createService(tmpDir);
+            try {
+                const rootPath = path.join(tmpDir, 'root.ditamap');
+                fs.writeFileSync(rootPath, `<?xml version="1.0"?>
+<map>
+  <mapref keyscope="product" href="product.ditamap"/>
+</map>`, 'utf-8');
+
+                const productPath = path.join(tmpDir, 'product.ditamap');
+                fs.writeFileSync(productPath, `<?xml version="1.0"?>
+<map>
+  <keydef keys="version" href="version.dita"/>
+</map>`, 'utf-8');
+
+                const keySpace = await service.buildKeySpace(rootPath);
+                const unqualified = keySpace.keys.get('version');
+                const qualified = keySpace.keys.get('product.version');
+                assert.ok(unqualified?.sourceLine, 'unqualified key should have sourceLine');
+                assert.ok(qualified?.sourceLine, 'qualified alias should have sourceLine');
+                assert.strictEqual(qualified!.sourceLine, unqualified!.sourceLine,
+                    'qualified alias sourceLine must equal original definition line');
+            } finally {
+                service.shutdown();
+                cleanup(tmpDir);
+            }
+        });
+    });
+
+    suite('scope explosion cap (Gap 7)', () => {
+
+        test('multi-token @keyscope on submap registers qualified aliases for each token', async () => {
+            // DITA spec: keyscope="a b" creates two independent child scopes.
+            // Both product.key and suite.key must be resolvable.
+            const tmpDir = makeTmpDir();
+            const service = createService(tmpDir);
+            try {
+                const rootPath = path.join(tmpDir, 'root.ditamap');
+                fs.writeFileSync(rootPath, `<?xml version="1.0"?>
+<map>
+  <mapref keyscope="product suite" href="lib.ditamap"/>
+</map>`, 'utf-8');
+
+                fs.writeFileSync(path.join(tmpDir, 'lib.ditamap'), `<?xml version="1.0"?>
+<map>
+  <keydef keys="version" href="version.dita"/>
+</map>`, 'utf-8');
+
+                const contextFile = path.join(tmpDir, 'topic.dita');
+                fs.writeFileSync(contextFile, '', 'utf-8');
+
+                const keySpace = await service.buildKeySpace(rootPath);
+                assert.ok(keySpace.keys.has('product.version'),
+                    'product.version should exist for first token of multi-token keyscope');
+                assert.ok(keySpace.keys.has('suite.version'),
+                    'suite.version should exist for second token of multi-token keyscope');
+
+                const r1 = await service.resolveKey('product.version', contextFile);
+                assert.ok(r1?.targetFile?.endsWith('version.dita'),
+                    'product.version should resolve to version.dita');
+                const r2 = await service.resolveKey('suite.version', contextFile);
+                assert.ok(r2?.targetFile?.endsWith('version.dita'),
+                    'suite.version should resolve to version.dita');
+            } finally {
+                service.shutdown();
+                cleanup(tmpDir);
+            }
+        });
+
+        test('nested multi-token keyscopes produce cross-product qualified aliases', async () => {
+            // parent keyscope="x y", child keyscope="c d" → should produce x.c, x.d, y.c, y.d
+            const tmpDir = makeTmpDir();
+            const service = createService(tmpDir);
+            try {
+                const rootPath = path.join(tmpDir, 'root.ditamap');
+                fs.writeFileSync(rootPath, `<?xml version="1.0"?>
+<map>
+  <mapref keyscope="x y" href="parent.ditamap"/>
+</map>`, 'utf-8');
+
+                fs.writeFileSync(path.join(tmpDir, 'parent.ditamap'), `<?xml version="1.0"?>
+<map>
+  <mapref keyscope="c d" href="child.ditamap"/>
+</map>`, 'utf-8');
+
+                fs.writeFileSync(path.join(tmpDir, 'child.ditamap'), `<?xml version="1.0"?>
+<map>
+  <keydef keys="api" href="api.dita"/>
+</map>`, 'utf-8');
+
+                const keySpace = await service.buildKeySpace(rootPath);
+                for (const prefix of ['x.c', 'x.d', 'y.c', 'y.d']) {
+                    assert.ok(keySpace.keys.has(`${prefix}.api`),
+                        `${prefix}.api should exist from cross-product keyscope expansion`);
+                }
+            } finally {
+                service.shutdown();
+                cleanup(tmpDir);
+            }
+        });
+
+        test('scope explosion warning is set when MAX_KEY_SPACE_ENTRIES is exceeded', async () => {
+            // Build a key space large enough to trigger the cap.
+            // 500 scopes × 101 keys each ≈ 50,500 qualified aliases > 50,000 cap.
+            const tmpDir = makeTmpDir();
+            const service = createService(tmpDir);
+            try {
+                const SCOPE_COUNT = 500;
+                const KEYS_PER_SCOPE = 101;
+                const rootPath = path.join(tmpDir, 'root.ditamap');
+                const submapRefs = Array.from({ length: SCOPE_COUNT }, (_, i) =>
+                    `  <mapref keyscope="scope${i}" href="scope${i}.ditamap"/>`
+                ).join('\n');
+                fs.writeFileSync(rootPath,
+                    `<?xml version="1.0"?>\n<map>\n${submapRefs}\n</map>`, 'utf-8');
+
+                for (let i = 0; i < SCOPE_COUNT; i++) {
+                    const keydefs = Array.from({ length: KEYS_PER_SCOPE }, (_, k) =>
+                        `  <keydef keys="key${k}" href="t${k}.dita"/>`
+                    ).join('\n');
+                    fs.writeFileSync(
+                        path.join(tmpDir, `scope${i}.ditamap`),
+                        `<?xml version="1.0"?>\n<map>\n${keydefs}\n</map>`, 'utf-8'
+                    );
+                }
+
+                const keySpace = await service.buildKeySpace(rootPath);
+                assert.ok(keySpace.scopeExplosionWarning === true,
+                    'scopeExplosionWarning should be set when entry cap is exceeded');
+                assert.ok(keySpace.keys.size <= 50_000,
+                    'keys map must not exceed MAX_KEY_SPACE_ENTRIES');
+            } finally {
+                service.shutdown();
+                cleanup(tmpDir);
+            }
+        });
+    });
+
+    suite('deferred peer map loading (Gap 4)', () => {
+
+        test('peer mapref with @keyscope is not inlined into main key space', async () => {
+            const tmpDir = makeTmpDir();
+            const service = createService(tmpDir);
+            try {
+                const rootPath = path.join(tmpDir, 'root.ditamap');
+                fs.writeFileSync(rootPath, `<?xml version="1.0"?>
+<map>
+  <keydef keys="local" href="local.dita"/>
+  <mapref href="peer.ditamap" scope="peer" keyscope="peerScope"/>
+</map>`, 'utf-8');
+
+                const peerPath = path.join(tmpDir, 'peer.ditamap');
+                fs.writeFileSync(peerPath, `<?xml version="1.0"?>
+<map>
+  <keydef keys="peerKey" href="peer-topic.dita"/>
+</map>`, 'utf-8');
+
+                const keySpace = await service.buildKeySpace(rootPath);
+                // local key must be present
+                assert.ok(keySpace.keys.has('local'), 'local key should be in main key space');
+                // peer map's key must NOT be inlined
+                assert.ok(!keySpace.keys.has('peerKey'),
+                    'peer map key must not be inlined into root key space');
+                // the peer map should be recorded in deferredPeerMaps
+                assert.ok(keySpace.deferredPeerMaps.has('peerScope'),
+                    'peerScope should be recorded as a deferred peer map');
+            } finally {
+                service.shutdown();
+                cleanup(tmpDir);
+            }
+        });
+
+        test('resolveKey lazily loads peer map and returns key with scope prefix', async () => {
+            const tmpDir = makeTmpDir();
+            const service = createService(tmpDir);
+            try {
+                const rootPath = path.join(tmpDir, 'root.ditamap');
+                fs.writeFileSync(rootPath, `<?xml version="1.0"?>
+<map>
+  <mapref href="peer.ditamap" scope="peer" keyscope="peerScope"/>
+</map>`, 'utf-8');
+
+                const peerPath = path.join(tmpDir, 'peer.ditamap');
+                fs.writeFileSync(peerPath, `<?xml version="1.0"?>
+<map>
+  <keydef keys="peerKey" href="peer-topic.dita"/>
+</map>`, 'utf-8');
+
+                const contextFile = path.join(tmpDir, 'topic.dita');
+                fs.writeFileSync(contextFile, '', 'utf-8');
+
+                const result = await service.resolveKey('peerScope.peerKey', contextFile);
+                assert.ok(result, 'resolveKey should lazily load peer map and resolve peerScope.peerKey');
+                assert.ok(result!.targetFile?.endsWith('peer-topic.dita'),
+                    'resolved key should point to peer-topic.dita');
+            } finally {
+                service.shutdown();
+                cleanup(tmpDir);
+            }
+        });
+
+        test('peer mapref without @keyscope is ignored (no deferred registration)', async () => {
+            const tmpDir = makeTmpDir();
+            const service = createService(tmpDir);
+            try {
+                const rootPath = path.join(tmpDir, 'root.ditamap');
+                fs.writeFileSync(rootPath, `<?xml version="1.0"?>
+<map>
+  <mapref href="peer.ditamap" scope="peer"/>
+</map>`, 'utf-8');
+
+                const peerPath = path.join(tmpDir, 'peer.ditamap');
+                fs.writeFileSync(peerPath, `<?xml version="1.0"?>
+<map>
+  <keydef keys="orphan" href="orphan.dita"/>
+</map>`, 'utf-8');
+
+                const keySpace = await service.buildKeySpace(rootPath);
+                assert.strictEqual(keySpace.deferredPeerMaps.size, 0,
+                    'peer mapref without @keyscope must not register a deferred map');
+            } finally {
+                service.shutdown();
+                cleanup(tmpDir);
+            }
+        });
+
+        test('nested key in peer map resolves via scope-qualified name', async () => {
+            const tmpDir = makeTmpDir();
+            const service = createService(tmpDir);
+            try {
+                const rootPath = path.join(tmpDir, 'root.ditamap');
+                fs.writeFileSync(rootPath, `<?xml version="1.0"?>
+<map>
+  <mapref href="peer.ditamap" scope="peer" keyscope="companion"/>
+</map>`, 'utf-8');
+
+                const peerPath = path.join(tmpDir, 'peer.ditamap');
+                fs.writeFileSync(peerPath, `<?xml version="1.0"?>
+<map>
+  <keydef keys="alpha" href="alpha.dita"/>
+  <keydef keys="beta" href="beta.dita"/>
+</map>`, 'utf-8');
+
+                const contextFile = path.join(tmpDir, 'topic.dita');
+                fs.writeFileSync(contextFile, '', 'utf-8');
+
+                const alpha = await service.resolveKey('companion.alpha', contextFile);
+                assert.ok(alpha?.targetFile?.endsWith('alpha.dita'), 'companion.alpha should resolve');
+
+                const beta = await service.resolveKey('companion.beta', contextFile);
+                assert.ok(beta?.targetFile?.endsWith('beta.dita'), 'companion.beta should resolve');
+
+                const missing = await service.resolveKey('companion.noSuchKey', contextFile);
+                assert.strictEqual(missing, null, 'companion.noSuchKey should return null');
+            } finally {
+                service.shutdown();
+                cleanup(tmpDir);
+            }
+        });
+    });
+
+    suite('XML-parser key extraction (Gap 5)', () => {
+
+        test('multi-line attribute value is correctly parsed', async () => {
+            const tmpDir = makeTmpDir();
+            const service = createService(tmpDir);
+            try {
+                const mapPath = path.join(tmpDir, 'root.ditamap');
+                // href attribute value split across lines (multi-line attribute)
+                fs.writeFileSync(mapPath, `<?xml version="1.0"?>
+<map>
+  <keydef keys="multiline"
+          href="target.dita"
+          scope="local"/>
+</map>`, 'utf-8');
+
+                const keySpace = await service.buildKeySpace(mapPath);
+                assert.ok(keySpace.keys.has('multiline'),
+                    'key with multi-line attributes should be extracted');
+                assert.ok(keySpace.keys.get('multiline')!.targetFile?.endsWith('target.dita'),
+                    'href from multi-line element should be resolved correctly');
+            } finally {
+                service.shutdown();
+                cleanup(tmpDir);
+            }
+        });
+
+        test('namespace-prefixed href attribute (xlink:href) is resolved', async () => {
+            const tmpDir = makeTmpDir();
+            const service = createService(tmpDir);
+            try {
+                const mapPath = path.join(tmpDir, 'root.ditamap');
+                fs.writeFileSync(mapPath, `<?xml version="1.0"?>
+<map xmlns:xlink="http://www.w3.org/1999/xlink">
+  <keydef keys="nskey" xlink:href="ns-target.dita"/>
+</map>`, 'utf-8');
+
+                const keySpace = await service.buildKeySpace(mapPath);
+                assert.ok(keySpace.keys.has('nskey'),
+                    'key with namespace-prefixed href should be extracted');
+                assert.ok(keySpace.keys.get('nskey')!.targetFile?.endsWith('ns-target.dita'),
+                    'namespace-prefixed href should resolve to correct target file');
+            } finally {
+                service.shutdown();
+                cleanup(tmpDir);
+            }
+        });
+
+        test('falls back to regex and still extracts keys when XML is malformed', async () => {
+            const tmpDir = makeTmpDir();
+            const service = createService(tmpDir);
+            try {
+                // Deliberately unclosed element to force regex fallback
+                const mapPath = path.join(tmpDir, 'root.ditamap');
+                fs.writeFileSync(mapPath, `<?xml version="1.0"?>
+<map>
+  <keydef keys="fallback" href="fallback.dita">
+  <keydef keys="also-fallback" href="also.dita"/>
+`, 'utf-8');  // missing </map>
+
+                const keySpace = await service.buildKeySpace(mapPath);
+                // At least the self-closing one should survive regex fallback
+                assert.ok(keySpace.keys.has('also-fallback'),
+                    'regex fallback should still extract self-closing keydef');
+            } finally {
+                service.shutdown();
+                cleanup(tmpDir);
+            }
+        });
+
+        test('inline keyword metadata extracted via XML parser', async () => {
+            const tmpDir = makeTmpDir();
+            const service = createService(tmpDir);
+            try {
+                const mapPath = path.join(tmpDir, 'root.ditamap');
+                fs.writeFileSync(mapPath, `<?xml version="1.0"?>
+<map>
+  <keydef keys="version">
+    <topicmeta>
+      <keywords><keyword>3.2</keyword></keywords>
+    </topicmeta>
+  </keydef>
+</map>`, 'utf-8');
+
+                const keySpace = await service.buildKeySpace(mapPath);
+                assert.ok(keySpace.keys.has('version'), 'inline keydef should be extracted');
+                const def = keySpace.keys.get('version')!;
+                assert.strictEqual(def.inlineContent, '3.2',
+                    'inline keyword content should be extracted via XML parser');
+            } finally {
+                service.shutdown();
+                cleanup(tmpDir);
+            }
+        });
+
+        test('topicmeta returned as array (invalid DITA) does not crash — metadata silently empty', async () => {
+            // fxp returns an array when the same element name appears multiple times.
+            // The fix normalises this to the first element instead of treating the
+            // array as a Record, which previously caused all meta lookups to return undefined.
+            const tmpDir = makeTmpDir();
+            const service = createService(tmpDir);
+            try {
+                const mapPath = path.join(tmpDir, 'root.ditamap');
+                // Manually write raw XML with two <topicmeta> blocks (invalid but parseable)
+                fs.writeFileSync(mapPath,
+                    `<?xml version="1.0"?>\n<map>\n` +
+                    `  <keydef keys="dup-meta">\n` +
+                    `    <topicmeta><navtitle>First</navtitle></topicmeta>\n` +
+                    `    <topicmeta><navtitle>Second</navtitle></topicmeta>\n` +
+                    `  </keydef>\n</map>`,
+                    'utf-8'
+                );
+
+                // Must not throw; metadata from the first topicmeta should be used
+                const keySpace = await service.buildKeySpace(mapPath);
+                assert.ok(keySpace.keys.has('dup-meta'), 'key should still be extracted');
+                const def = keySpace.keys.get('dup-meta')!;
+                // Either metadata is extracted from first topicmeta or gracefully absent
+                // — the important invariant is no crash and keyName is correct
+                assert.strictEqual(def.keyName, 'dup-meta', 'key name must be correct');
+            } finally {
+                service.shutdown();
+                cleanup(tmpDir);
+            }
+        });
+
+        test('XML processing instruction (?xml) is not treated as a key-bearing element', async () => {
+            const tmpDir = makeTmpDir();
+            const service = createService(tmpDir);
+            try {
+                const mapPath = path.join(tmpDir, 'root.ditamap');
+                fs.writeFileSync(mapPath, `<?xml version="1.0" encoding="UTF-8"?>
+<map>
+  <keydef keys="pi-test" href="pi-test.dita"/>
+</map>`, 'utf-8');
+
+                const keySpace = await service.buildKeySpace(mapPath);
+                assert.ok(keySpace.keys.has('pi-test'), 'real key should be found');
+                // Verify no spurious keys leaked from the XML declaration
+                const allKeys = Array.from(keySpace.keys.keys());
+                assert.ok(!allKeys.some(k => k.includes('version') || k.includes('encoding')),
+                    'XML declaration attributes must not become key names');
+            } finally {
+                service.shutdown();
+                cleanup(tmpDir);
+            }
+        });
+    });
+
+    suite('pydita-inspired test scenarios', () => {
+
+        test('multiple @keys tokens on one keydef — all keys resolve to same target', async () => {
+            // pydita: keys="topic01 second-key-name-topic01" — both should resolve to same href
+            const tmpDir = makeTmpDir();
+            const service = createService(tmpDir);
+            try {
+                const mapPath = path.join(tmpDir, 'root.ditamap');
+                fs.writeFileSync(mapPath, `<?xml version="1.0"?>
+<map>
+  <keydef keys="topic01 alias-topic01" href="topic-01.dita"/>
+</map>`, 'utf-8');
+
+                const keySpace = await service.buildKeySpace(mapPath);
+                assert.ok(keySpace.keys.has('topic01'), 'primary key should be registered');
+                assert.ok(keySpace.keys.has('alias-topic01'), 'alias key should be registered');
+                assert.ok(
+                    keySpace.keys.get('topic01')!.targetFile?.endsWith('topic-01.dita'),
+                    'primary key should resolve to topic-01.dita'
+                );
+                assert.ok(
+                    keySpace.keys.get('alias-topic01')!.targetFile?.endsWith('topic-01.dita'),
+                    'alias key should also resolve to topic-01.dita'
+                );
+            } finally {
+                service.shutdown();
+                cleanup(tmpDir);
+            }
+        });
+
+        test('cross-sibling scope path returns null (submap02.submap01.topic-01)', async () => {
+            // pydita: rootSpace.resolveKey("submap02.submap01.topic-01") is None
+            // A key visible inside submap01 is NOT reachable via submap02.submap01.xxx
+            const tmpDir = makeTmpDir();
+            const service = createService(tmpDir);
+            try {
+                const rootPath = path.join(tmpDir, 'root.ditamap');
+                fs.writeFileSync(rootPath, `<?xml version="1.0"?>
+<map>
+  <mapref keyscope="submap01" href="submap01.ditamap"/>
+  <mapref keyscope="submap02" href="submap02.ditamap"/>
+</map>`, 'utf-8');
+
+                fs.writeFileSync(path.join(tmpDir, 'submap01.ditamap'), `<?xml version="1.0"?>
+<map>
+  <keydef keys="topic-01" href="sub01-topic01.dita"/>
+</map>`, 'utf-8');
+
+                fs.writeFileSync(path.join(tmpDir, 'submap02.ditamap'), `<?xml version="1.0"?>
+<map>
+  <keydef keys="doc" href="sub02-doc.dita"/>
+</map>`, 'utf-8');
+
+                const contextFile = path.join(tmpDir, 'topic.dita');
+                fs.writeFileSync(contextFile, '', 'utf-8');
+
+                const keySpace = await service.buildKeySpace(rootPath);
+                assert.ok(!keySpace.keys.has('submap02.submap01.topic-01'),
+                    'cross-sibling scope path submap02.submap01.topic-01 must not exist in key map');
+
+                const result = await service.resolveKey('submap02.submap01.topic-01', contextFile);
+                assert.strictEqual(result, null,
+                    'resolveKey must return null for cross-sibling scope path');
+            } finally {
+                service.shutdown();
+                cleanup(tmpDir);
+            }
+        });
+
+        test('push-down: inherited key in child scope has same source file as root key', async () => {
+            // pydita: keydef2.getKeyDefiner() is keydef3.getKeyDefiner()
+            // After push-down, topic-02 resolves in submap01 context with same targetFile as root
+            const tmpDir = makeTmpDir();
+            const service = createService(tmpDir);
+            try {
+                const rootPath = path.join(tmpDir, 'root.ditamap');
+                fs.writeFileSync(rootPath, `<?xml version="1.0"?>
+<map>
+  <keydef keys="topic-02" href="root-topic-02.dita"/>
+  <mapref keyscope="submap01" href="submap01.ditamap"/>
+</map>`, 'utf-8');
+
+                fs.writeFileSync(path.join(tmpDir, 'submap01.ditamap'), `<?xml version="1.0"?>
+<map>
+  <keydef keys="topic-03" href="sub-topic-03.dita"/>
+</map>`, 'utf-8');
+
+                const keySpace = await service.buildKeySpace(rootPath);
+
+                const rootDef = keySpace.keys.get('topic-02');
+                assert.ok(rootDef?.targetFile?.endsWith('root-topic-02.dita'),
+                    'root topic-02 should resolve to root-topic-02.dita');
+
+                // PushDown should inject topic-02 into submap01 namespace
+                const inheritedDef = keySpace.keys.get('submap01.topic-02');
+                assert.ok(inheritedDef?.targetFile?.endsWith('root-topic-02.dita'),
+                    'inherited submap01.topic-02 should point to same root-topic-02.dita');
+
+                // Child scope's own key is unaffected
+                const ownDef = keySpace.keys.get('submap01.topic-03');
+                assert.ok(ownDef?.targetFile?.endsWith('sub-topic-03.dita'),
+                    'submap01.topic-03 should point to sub-topic-03.dita');
+            } finally {
+                service.shutdown();
+                cleanup(tmpDir);
+            }
+        });
+
+        test('scope-on-root-map keyscope creates qualified aliases', async () => {
+            // pydita: "scope-on-root-map" in rootSpace.getScopeNames()
+            // resolveRootKeyref("scope-on-root-map.topic-01") returns non-null
+            const tmpDir = makeTmpDir();
+            const service = createService(tmpDir);
+            try {
+                const mapPath = path.join(tmpDir, 'root.ditamap');
+                fs.writeFileSync(mapPath, `<?xml version="1.0"?>
+<map keyscope="bundle">
+  <keydef keys="topic-01" href="topic.dita"/>
+</map>`, 'utf-8');
+
+                const contextFile = path.join(tmpDir, 'context.dita');
+                fs.writeFileSync(contextFile, '', 'utf-8');
+
+                const keySpace = await service.buildKeySpace(mapPath);
+                assert.ok(keySpace.keys.has('topic-01'), 'unqualified key should exist');
+                assert.ok(keySpace.keys.has('bundle.topic-01'),
+                    'root map @keyscope should create bundle.topic-01 qualified alias');
+
+                const result = await service.resolveKey('bundle.topic-01', contextFile);
+                assert.ok(result?.targetFile?.endsWith('topic.dita'),
+                    'bundle.topic-01 should resolve to topic.dita');
+            } finally {
+                service.shutdown();
+                cleanup(tmpDir);
+            }
+        });
+
+        test('string key — keydef with inline content and no href is identifiable', async () => {
+            // pydita: keyDef.isStringKey() → True when no href, has inline content
+            // Ditacraft equivalent: targetFile is absent, inlineContent is populated
+            const tmpDir = makeTmpDir();
+            const service = createService(tmpDir);
+            try {
+                const mapPath = path.join(tmpDir, 'root.ditamap');
+                fs.writeFileSync(mapPath, `<?xml version="1.0"?>
+<map>
+  <keydef keys="string-01">
+    <topicmeta>
+      <keywords><keyword>Acme Corp</keyword></keywords>
+    </topicmeta>
+  </keydef>
+  <keydef keys="topic-01" href="topic.dita"/>
+</map>`, 'utf-8');
+
+                const keySpace = await service.buildKeySpace(mapPath);
+
+                const stringKey = keySpace.keys.get('string-01');
+                assert.ok(stringKey, 'string key should be registered');
+                assert.ok(!stringKey!.targetFile,
+                    'string key must have no targetFile (no href)');
+                assert.strictEqual(stringKey!.inlineContent, 'Acme Corp',
+                    'string key inline keyword content should be "Acme Corp"');
+
+                const topicKey = keySpace.keys.get('topic-01');
+                assert.ok(topicKey?.targetFile?.endsWith('topic.dita'),
+                    'topic key should have targetFile pointing to topic.dita');
+            } finally {
+                service.shutdown();
+                cleanup(tmpDir);
+            }
+        });
+
+        test('scope explosion — 25 sibling scopes does not hang', async () => {
+            // pydita: test_scope_explosion with keyscope-explosion.ditamap
+            // Verifies the algorithm handles many sibling scopes without crashing or timing out
+            const tmpDir = makeTmpDir();
+            const service = createService(tmpDir);
+            try {
+                const SCOPE_COUNT = 25;
+                const rootPath = path.join(tmpDir, 'root.ditamap');
+                const submapRefs = Array.from({ length: SCOPE_COUNT }, (_, i) =>
+                    `  <mapref keyscope="scope${i}" href="scope${i}.ditamap"/>`
+                ).join('\n');
+                fs.writeFileSync(rootPath,
+                    `<?xml version="1.0"?>\n<map>\n${submapRefs}\n</map>`, 'utf-8');
+
+                for (let i = 0; i < SCOPE_COUNT; i++) {
+                    fs.writeFileSync(
+                        path.join(tmpDir, `scope${i}.ditamap`),
+                        `<?xml version="1.0"?>\n<map>\n` +
+                        `  <keydef keys="key-a" href="topic-a.dita"/>\n` +
+                        `  <keydef keys="key-b" href="topic-b.dita"/>\n` +
+                        `</map>`, 'utf-8'
+                    );
+                }
+
+                const keySpace = await service.buildKeySpace(rootPath);
+
+                assert.ok(keySpace.keys.has('scope0.key-a'),
+                    'scope0.key-a should exist after explosion');
+                assert.ok(keySpace.keys.has(`scope${SCOPE_COUNT - 1}.key-b`),
+                    `scope${SCOPE_COUNT - 1}.key-b should exist after explosion`);
+                // If we reach here without timeout, the explosion test passes
+            } finally {
+                service.shutdown();
+                cleanup(tmpDir);
+            }
+        });
+    });
+
+    suite('peer map keyref chain scope fix (Bug 1)', () => {
+
+        test('keyref chain within scoped peer map resolves via correct scope prefix', async () => {
+            // Bug: followKeyrefChain was called with scopePrefix='' for all peer keys.
+            // A keyref defined within a named scope of the peer map (e.g. "inner.alias"
+            // → keyref="inner.real") would fail to find "inner.real" and instead return
+            // the alias definition unchanged.
+            const tmpDir = makeTmpDir();
+            const service = createService(tmpDir);
+            try {
+                const rootPath = path.join(tmpDir, 'root.ditamap');
+                fs.writeFileSync(rootPath, `<?xml version="1.0"?>
+<map>
+  <mapref href="peer.ditamap" scope="peer" keyscope="companion"/>
+</map>`, 'utf-8');
+
+                const peerPath = path.join(tmpDir, 'peer.ditamap');
+                fs.writeFileSync(peerPath, `<?xml version="1.0"?>
+<map keyscope="inner">
+  <keydef keys="alias" keyref="real"/>
+  <keydef keys="real" href="real.dita"/>
+</map>`, 'utf-8');
+
+                const contextFile = path.join(tmpDir, 'topic.dita');
+                fs.writeFileSync(contextFile, '', 'utf-8');
+
+                // resolveKey("companion.inner.alias") should follow:
+                //   companion → peer map, peerKey = "inner.alias"
+                //   inner.alias keyref → "real", peerKeyScope = "inner"
+                //   chain follows "inner.real" (scope-qualified) → real.dita
+                const result = await service.resolveKey('companion.inner.alias', contextFile);
+                assert.ok(result, 'peer key with keyref chain should resolve');
+                assert.ok(result!.targetFile?.endsWith('real.dita'),
+                    'keyref chain within scoped peer map should resolve to real.dita, not alias');
+            } finally {
+                service.shutdown();
+                cleanup(tmpDir);
+            }
+        });
+    });
+
+    suite('explainKey and reporting utilities', () => {
+
+        test('explainKey — unqualified match reports correct step', async () => {
+            const tmpDir = makeTmpDir();
+            const service = createService(tmpDir);
+            try {
+                const mapPath = path.join(tmpDir, 'root.ditamap');
+                fs.writeFileSync(mapPath, `<?xml version="1.0"?>
+<map>
+  <keydef keys="version" href="version.dita"/>
+</map>`, 'utf-8');
+                const contextFile = path.join(tmpDir, 'topic.dita');
+                fs.writeFileSync(contextFile, '', 'utf-8');
+
+                const report = await service.explainKey('version', contextFile);
+
+                assert.strictEqual(report.keyName, 'version');
+                assert.ok(report.resolvedDefinition, 'should resolve');
+                assert.ok(report.resolvedDefinition!.targetFile?.endsWith('version.dita'));
+                assert.ok(report.keyrefChain.length === 0, 'no keyref chain');
+
+                const unqualStep = report.steps.find(s => s.type === 'unqualified-lookup');
+                assert.ok(unqualStep, 'unqualified-lookup step should exist');
+                assert.ok(unqualStep!.found, 'step should be found');
+                assert.ok(unqualStep!.note.includes('first-BFS-encounter wins'),
+                    'note should explain why this definition won');
+            } finally {
+                service.shutdown();
+                cleanup(tmpDir);
+            }
+        });
+
+        test('explainKey — context-scope match reports context-scope-lookup step first', async () => {
+            const tmpDir = makeTmpDir();
+            const service = createService(tmpDir);
+            try {
+                const rootPath = path.join(tmpDir, 'root.ditamap');
+                fs.writeFileSync(rootPath, `<?xml version="1.0"?>
+<map>
+  <keydef keys="version" href="root-version.dita"/>
+  <mapref keyscope="product" href="product.ditamap"/>
+</map>`, 'utf-8');
+                fs.writeFileSync(path.join(tmpDir, 'product.ditamap'), `<?xml version="1.0"?>
+<map>
+  <keydef keys="version" href="product-version.dita"/>
+  <topicref href="guide.dita"/>
+</map>`, 'utf-8');
+                const guidePath = path.join(tmpDir, 'guide.dita');
+                fs.writeFileSync(guidePath, '', 'utf-8');
+
+                const report = await service.explainKey('version', guidePath);
+
+                assert.strictEqual(report.contextScope, 'product',
+                    'contextScope should be "product"');
+                const ctxStep = report.steps.find(s => s.type === 'context-scope-lookup');
+                assert.ok(ctxStep, 'context-scope-lookup step should be present');
+                assert.ok(ctxStep!.found, 'step should be found');
+                assert.ok(ctxStep!.note.includes('product'),
+                    'note should mention the winning scope');
+                assert.ok(report.resolvedDefinition?.targetFile?.endsWith('product-version.dita'),
+                    'should resolve to child-scope override');
+            } finally {
+                service.shutdown();
+                cleanup(tmpDir);
+            }
+        });
+
+        test('explainKey — failed lookup records all tried steps with notes', async () => {
+            const tmpDir = makeTmpDir();
+            const service = createService(tmpDir);
+            try {
+                const mapPath = path.join(tmpDir, 'root.ditamap');
+                fs.writeFileSync(mapPath, `<?xml version="1.0"?>
+<map>
+  <keydef keys="other" href="other.dita"/>
+</map>`, 'utf-8');
+                const contextFile = path.join(tmpDir, 'topic.dita');
+                fs.writeFileSync(contextFile, '', 'utf-8');
+
+                const report = await service.explainKey('missing-key', contextFile);
+
+                assert.strictEqual(report.resolvedDefinition, null,
+                    'resolvedDefinition should be null for missing key');
+                assert.ok(report.steps.length >= 1, 'at least one step should be recorded');
+                const failStep = report.steps.find(s => s.type === 'unqualified-lookup');
+                assert.ok(failStep, 'unqualified-lookup step should exist');
+                assert.ok(!failStep!.found, 'step should not be found');
+                assert.ok(failStep!.note.includes('missing-key'),
+                    'note should mention the key that was not found');
+            } finally {
+                service.shutdown();
+                cleanup(tmpDir);
+            }
+        });
+
+        test('explainKey — keyref chain records keyref-hop steps', async () => {
+            const tmpDir = makeTmpDir();
+            const service = createService(tmpDir);
+            try {
+                const mapPath = path.join(tmpDir, 'root.ditamap');
+                fs.writeFileSync(mapPath, `<?xml version="1.0"?>
+<map>
+  <keydef keys="alias" keyref="real"/>
+  <keydef keys="real" href="real.dita"/>
+</map>`, 'utf-8');
+                const contextFile = path.join(tmpDir, 'topic.dita');
+                fs.writeFileSync(contextFile, '', 'utf-8');
+
+                const report = await service.explainKey('alias', contextFile);
+
+                assert.ok(report.resolvedDefinition?.targetFile?.endsWith('real.dita'),
+                    'should resolve to final keyref target');
+                assert.ok(report.keyrefChain.length >= 2,
+                    'keyrefChain should contain at least alias and real');
+                assert.strictEqual(report.keyrefChain[0], 'alias');
+                assert.ok(report.keyrefChain.includes('real'));
+
+                const hopStep = report.steps.find(s => s.type === 'keyref-hop');
+                assert.ok(hopStep, 'keyref-hop step should be recorded');
+                assert.ok(hopStep!.note.includes('alias') && hopStep!.note.includes('real'),
+                    'keyref-hop note should show the from→to transition');
+            } finally {
+                service.shutdown();
+                cleanup(tmpDir);
+            }
+        });
+
+        test('explainKey — peer map lookup records peer-map-lookup step', async () => {
+            const tmpDir = makeTmpDir();
+            const service = createService(tmpDir);
+            try {
+                const rootPath = path.join(tmpDir, 'root.ditamap');
+                fs.writeFileSync(rootPath, `<?xml version="1.0"?>
+<map>
+  <mapref href="peer.ditamap" scope="peer" keyscope="companion"/>
+</map>`, 'utf-8');
+                fs.writeFileSync(path.join(tmpDir, 'peer.ditamap'), `<?xml version="1.0"?>
+<map>
+  <keydef keys="guide" href="guide.dita"/>
+</map>`, 'utf-8');
+                const contextFile = path.join(tmpDir, 'topic.dita');
+                fs.writeFileSync(contextFile, '', 'utf-8');
+
+                const report = await service.explainKey('companion.guide', contextFile);
+
+                assert.ok(report.resolvedDefinition?.targetFile?.endsWith('guide.dita'),
+                    'peer key should resolve');
+                const peerStep = report.steps.find(s => s.type === 'peer-map-lookup');
+                assert.ok(peerStep, 'peer-map-lookup step should exist');
+                assert.ok(peerStep!.found, 'peer-map step should be found');
+                assert.ok(peerStep!.note.includes('companion') || peerStep!.note.includes('peer.ditamap'),
+                    'peer-map step note should mention scope or map name');
+            } finally {
+                service.shutdown();
+                cleanup(tmpDir);
+            }
+        });
+
+        test('reportKeySpace produces text with key names and source info', async () => {
+            const tmpDir = makeTmpDir();
+            const service = createService(tmpDir);
+            try {
+                const mapPath = path.join(tmpDir, 'root.ditamap');
+                fs.writeFileSync(mapPath, `<?xml version="1.0"?>
+<map>
+  <keydef keys="alpha" href="alpha.dita"/>
+  <keydef keys="beta" href="beta.dita"/>
+  <keydef keys="alpha" href="duplicate.dita"/>
+</map>`, 'utf-8');
+
+                const keySpace = await service.buildKeySpace(mapPath);
+                const report = reportKeySpace(keySpace);
+
+                assert.ok(typeof report === 'string' && report.length > 0,
+                    'report should be a non-empty string');
+                assert.ok(report.includes('alpha'), 'report should mention key "alpha"');
+                assert.ok(report.includes('beta'), 'report should mention key "beta"');
+                assert.ok(report.includes('root.ditamap'), 'report should reference the root map');
+                assert.ok(report.includes('Duplicate keys'), 'report should list duplicate keys');
+            } finally {
+                service.shutdown();
+                cleanup(tmpDir);
+            }
+        });
+
+        test('formatResolutionReport renders resolved key with winner line', async () => {
+            const tmpDir = makeTmpDir();
+            const service = createService(tmpDir);
+            try {
+                const mapPath = path.join(tmpDir, 'root.ditamap');
+                fs.writeFileSync(mapPath, `<?xml version="1.0"?>
+<map>
+  <keydef keys="version" href="version.dita"/>
+</map>`, 'utf-8');
+                const contextFile = path.join(tmpDir, 'topic.dita');
+                fs.writeFileSync(contextFile, '', 'utf-8');
+
+                const explainResult = await service.explainKey('version', contextFile);
+                const text = formatResolutionReport(explainResult);
+
+                assert.ok(text.includes('RESOLVED'), 'text should say RESOLVED');
+                assert.ok(text.includes('version'), 'text should include the key name');
+                assert.ok(text.includes('Winner:'), 'text should show Winner line');
+                assert.ok(text.includes('Steps:'), 'text should show Steps section');
+            } finally {
+                service.shutdown();
+                cleanup(tmpDir);
+            }
+        });
+
+        test('formatResolutionReport renders NOT FOUND when key is missing', async () => {
+            const tmpDir = makeTmpDir();
+            const service = createService(tmpDir);
+            try {
+                const mapPath = path.join(tmpDir, 'root.ditamap');
+                fs.writeFileSync(mapPath, `<?xml version="1.0"?>\n<map/>\n`, 'utf-8');
+                const contextFile = path.join(tmpDir, 'topic.dita');
+                fs.writeFileSync(contextFile, '', 'utf-8');
+
+                const explainResult = await service.explainKey('no-such-key', contextFile);
+                const text = formatResolutionReport(explainResult);
+
+                assert.ok(text.includes('NOT FOUND'), 'text should say NOT FOUND');
+                assert.ok(text.includes('no-such-key'), 'text should include the key name');
+                const failStep = explainResult.steps.find(s => !s.found);
+                assert.ok(failStep, 'at least one step should have found=false');
             } finally {
                 service.shutdown();
                 cleanup(tmpDir);

--- a/server/test/keySpaceService.test.ts
+++ b/server/test/keySpaceService.test.ts
@@ -893,4 +893,197 @@ suite('KeySpaceService', () => {
             }
         });
     });
+
+    suite('inline scope branches (@keyscope on non-map topicrefs)', () => {
+
+        test('key inside inline scope branch is registered under child scope', async () => {
+            const tmpDir = makeTmpDir();
+            const service = createService(tmpDir);
+            try {
+                const mapPath = path.join(tmpDir, 'root.ditamap');
+                fs.writeFileSync(mapPath, `<?xml version="1.0"?>
+<map>
+  <keydef keys="global" href="global.dita"/>
+  <topicref keyscope="branch">
+    <keydef keys="local" href="local.dita"/>
+  </topicref>
+</map>`, 'utf-8');
+
+                const keySpace = await service.buildKeySpace(mapPath);
+                assert.ok(keySpace.keys.has('global'), 'root-scope key should exist');
+                assert.ok(keySpace.keys.has('local'), 'unqualified child key should still exist');
+                assert.ok(keySpace.keys.has('branch.local'),
+                    'child-scope qualified key branch.local should exist');
+                assert.ok(
+                    keySpace.keys.get('branch.local')!.targetFile?.endsWith('local.dita'),
+                    'branch.local should point to local.dita'
+                );
+            } finally {
+                service.shutdown();
+                cleanup(tmpDir);
+            }
+        });
+
+        test('root-scope key is not mistakenly put in inline scope', async () => {
+            const tmpDir = makeTmpDir();
+            const service = createService(tmpDir);
+            try {
+                const mapPath = path.join(tmpDir, 'root.ditamap');
+                fs.writeFileSync(mapPath, `<?xml version="1.0"?>
+<map>
+  <keydef keys="shared" href="shared.dita"/>
+  <topicref keyscope="branch">
+    <keydef keys="branchOnly" href="branchOnly.dita"/>
+  </topicref>
+</map>`, 'utf-8');
+
+                const keySpace = await service.buildKeySpace(mapPath);
+                // shared is in root scope — branch.shared should appear via PushDown, not direct
+                assert.ok(!keySpace.keys.has('branch.branchOnly') === false,
+                    'branch.branchOnly should exist');
+                // shared should not be accidentally registered as branch.shared via direct extraction
+                // (PushDown will add it, so we just verify the direct key target is correct)
+                const sharedDef = keySpace.keys.get('shared');
+                assert.ok(sharedDef?.targetFile?.endsWith('shared.dita'),
+                    'root shared key should point to shared.dita');
+            } finally {
+                service.shutdown();
+                cleanup(tmpDir);
+            }
+        });
+
+        test('topic inside inline scope branch is recorded in topicToScope', async () => {
+            const tmpDir = makeTmpDir();
+            const service = createService(tmpDir);
+            try {
+                const mapPath = path.join(tmpDir, 'root.ditamap');
+                fs.writeFileSync(mapPath, `<?xml version="1.0"?>
+<map>
+  <topicref keyscope="branch">
+    <topicref href="guide.dita"/>
+  </topicref>
+</map>`, 'utf-8');
+
+                const guidePath = path.join(tmpDir, 'guide.dita');
+                fs.writeFileSync(guidePath, '', 'utf-8');
+
+                const keySpace = await service.buildKeySpace(mapPath);
+                const scopePrefix = keySpace.topicToScope.get(path.normalize(guidePath));
+                assert.strictEqual(scopePrefix, 'branch',
+                    'topic inside inline scope branch should map to that scope');
+            } finally {
+                service.shutdown();
+                cleanup(tmpDir);
+            }
+        });
+
+        test('nested inline scopes produce compound scope prefix', async () => {
+            const tmpDir = makeTmpDir();
+            const service = createService(tmpDir);
+            try {
+                const mapPath = path.join(tmpDir, 'root.ditamap');
+                fs.writeFileSync(mapPath, `<?xml version="1.0"?>
+<map>
+  <topicref keyscope="outer">
+    <topicref keyscope="inner">
+      <keydef keys="deep" href="deep.dita"/>
+    </topicref>
+    <keydef keys="mid" href="mid.dita"/>
+  </topicref>
+  <keydef keys="root" href="root.dita"/>
+</map>`, 'utf-8');
+
+                const keySpace = await service.buildKeySpace(mapPath);
+                assert.ok(keySpace.keys.has('root'), 'root key should exist');
+                assert.ok(keySpace.keys.has('outer.mid'), 'outer scope key should be qualified');
+                assert.ok(keySpace.keys.has('outer.inner.deep'),
+                    'nested inline scope key should produce compound qualified name');
+                assert.ok(
+                    keySpace.keys.get('outer.inner.deep')!.targetFile?.endsWith('deep.dita'),
+                    'outer.inner.deep should point to deep.dita'
+                );
+            } finally {
+                service.shutdown();
+                cleanup(tmpDir);
+            }
+        });
+
+        test('@keys on the keyscoped topicref element itself belong to child scope', async () => {
+            const tmpDir = makeTmpDir();
+            const service = createService(tmpDir);
+            try {
+                const mapPath = path.join(tmpDir, 'root.ditamap');
+                fs.writeFileSync(mapPath, `<?xml version="1.0"?>
+<map>
+  <topicref keyscope="sub" keys="sub-entry" href="overview.dita">
+    <keydef keys="detail" href="detail.dita"/>
+  </topicref>
+</map>`, 'utf-8');
+
+                const keySpace = await service.buildKeySpace(mapPath);
+                assert.ok(keySpace.keys.has('sub.sub-entry'),
+                    '@keys on keyscoped topicref should be in child scope (sub.sub-entry)');
+                assert.ok(keySpace.keys.has('sub.detail'),
+                    'child keydef should also be in child scope (sub.detail)');
+            } finally {
+                service.shutdown();
+                cleanup(tmpDir);
+            }
+        });
+
+        test('inline scope PushDown: root key inherited by inline scope', async () => {
+            const tmpDir = makeTmpDir();
+            const service = createService(tmpDir);
+            try {
+                const mapPath = path.join(tmpDir, 'root.ditamap');
+                fs.writeFileSync(mapPath, `<?xml version="1.0"?>
+<map>
+  <keydef keys="brand" href="brand.dita"/>
+  <topicref keyscope="product">
+    <keydef keys="widget" href="widget.dita"/>
+  </topicref>
+</map>`, 'utf-8');
+
+                const keySpace = await service.buildKeySpace(mapPath);
+                // PushDown should inherit root "brand" into the "product" inline scope
+                assert.ok(keySpace.keys.has('product.brand'),
+                    'PushDown should make root brand accessible as product.brand');
+                assert.ok(
+                    keySpace.keys.get('product.brand')!.targetFile?.endsWith('brand.dita'),
+                    'product.brand should point to brand.dita'
+                );
+            } finally {
+                service.shutdown();
+                cleanup(tmpDir);
+            }
+        });
+
+        test('inline scope contains a submap: submap queued with combined scope prefix', async () => {
+            const tmpDir = makeTmpDir();
+            const service = createService(tmpDir);
+            try {
+                const rootPath = path.join(tmpDir, 'root.ditamap');
+                fs.writeFileSync(rootPath, `<?xml version="1.0"?>
+<map>
+  <topicref keyscope="outer">
+    <mapref href="inner.ditamap" keyscope="inner"/>
+  </topicref>
+</map>`, 'utf-8');
+
+                const innerPath = path.join(tmpDir, 'inner.ditamap');
+                fs.writeFileSync(innerPath, `<?xml version="1.0"?>
+<map>
+  <keydef keys="lib" href="lib.dita"/>
+</map>`, 'utf-8');
+
+                const keySpace = await service.buildKeySpace(rootPath);
+                // inner.ditamap should be processed as "outer.inner" scope
+                assert.ok(keySpace.keys.has('outer.inner.lib'),
+                    'submap inside inline scope should get compound prefix outer.inner.lib');
+            } finally {
+                service.shutdown();
+                cleanup(tmpDir);
+            }
+        });
+    });
 });

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -14,6 +14,7 @@
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "moduleResolution": "node",
+    "ignoreDeprecations": "5.0",
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noImplicitReturns": true,

--- a/src/utils/keySpaceResolver.ts
+++ b/src/utils/keySpaceResolver.ts
@@ -22,6 +22,7 @@ export interface KeyDefinition {
     sourceMap: string;             // Absolute path to map where key was defined
     scope?: string;                // Key scope (local, peer, external)
     processingRole?: string;       // resource-only, normal, etc.
+    keyref?: string;               // Indirect key reference — resolution follows this chain
     metadata?: KeyMetadata;        // Additional metadata from topicmeta
 }
 
@@ -633,6 +634,12 @@ export class KeySpaceResolver implements vscode.Disposable {
                     keyDef.processingRole = roleMatch[1];
                 }
 
+                // Extract keyref (indirect key alias)
+                const keyrefMatch = fullElement.match(/\bkeyref\s*=\s*["']([^"']+)["']/i);
+                if (keyrefMatch) {
+                    keyDef.keyref = keyrefMatch[1];
+                }
+
                 // Check for inline content (keydef without href)
                 if (!keyDef.targetFile) {
                     // Try to extract inline content from topicmeta/keywords
@@ -763,20 +770,21 @@ export class KeySpaceResolver implements vscode.Disposable {
         // Build key space
         const keySpace = await this.buildKeySpace(rootMap);
 
-        // Lookup key
+        // Lookup key, then follow any @keyref chain to the final definition.
         const keyDef = keySpace.keys.get(keyName);
 
         if (keyDef) {
+            const resolved = this.followKeyrefChain(keyDef, keySpace.keys);
             logger.debug('Key resolved', {
                 keyName,
-                targetFile: keyDef.targetFile,
-                sourceMap: path.basename(keyDef.sourceMap)
+                targetFile: resolved.targetFile,
+                sourceMap: path.basename(resolved.sourceMap)
             });
-        } else {
-            logger.debug('Key not found in key space', { keyName });
+            return resolved;
         }
 
-        return keyDef || null;
+        logger.debug('Key not found in key space', { keyName });
+        return null;
     }
 
     /**
@@ -938,6 +946,26 @@ export class KeySpaceResolver implements vscode.Disposable {
         this.keySpaceCache.clear();
         this.rootMapCache.clear();
         logger.info('Key space cache cleared');
+    }
+
+    /**
+     * Follow @keyref chains up to hopsRemaining hops.
+     * Returns the original definition if no chain exists, the target is missing,
+     * the hop limit is reached, or a cycle is detected.
+     */
+    private followKeyrefChain(
+        keyDef: KeyDefinition,
+        keys: Map<string, KeyDefinition>,
+        hopsRemaining = 3,
+        visited = new Set<string>()
+    ): KeyDefinition {
+        if (!keyDef.keyref || hopsRemaining <= 0 || visited.has(keyDef.keyName)) {
+            return keyDef;
+        }
+        visited.add(keyDef.keyName);
+        const next = keys.get(keyDef.keyref);
+        if (!next) return keyDef;
+        return this.followKeyrefChain(next, keys, hopsRemaining - 1, visited);
     }
 
     /**

--- a/src/utils/keySpaceResolver.ts
+++ b/src/utils/keySpaceResolver.ts
@@ -398,11 +398,13 @@ export class KeySpaceResolver implements vscode.Disposable {
             keySpace.mapHierarchy.push(currentMap);
 
             try {
-                // Read and parse current map — strip comments/CDATA to avoid false matches
+                // Read and parse current map — strip comments/CDATA, then reltable blocks.
+                // reltable hrefs are relationship-table links, not key space content (spec §2.4.4).
                 const rawContent = await this.readFileAsync(currentMap);
                 const mapContent = rawContent
                     .replace(/<!--[\s\S]*?-->/g, (m) => ' '.repeat(m.length))
-                    .replace(/<!\[CDATA\[[\s\S]*?]]>/g, (m) => ' '.repeat(m.length));
+                    .replace(/<!\[CDATA\[[\s\S]*?]]>/g, (m) => ' '.repeat(m.length))
+                    .replace(/<reltable\b[^>]*>[\s\S]*?<\/reltable\s*>/gi, '');
 
                 // Extract key definitions
                 const keys = this.extractKeyDefinitions(mapContent, currentMap);


### PR DESCRIPTION
Improves the key space algorithm in both the server-side service and the
client-side resolver to fully implement DITA 1.3/2.0 key scoping semantics.

## Changes

### Algorithm (three ordered phases)

| Phase | What it does |
|-------|--------------|
| **Phase 1 – BFS traversal** | Walk the map hierarchy; collect key definitions into the flat `keys` map; populate `scopeDirectKeys` (per-scope direct key list) and `topicToScope` (topic file → owning scope prefix). |
| **Phase 2 – PushDown** | After BFS, walk every non-root scope. For each ancestor scope, inject its direct keys into the descendant's qualified namespace (e.g. `product.lib.version`) at lower priority (existing child-scope definitions are never overwritten). |
| **Phase 3 – Keyref chain** | In `resolveKey`, follow any `@keyref` chain on the returned definition up to 3 hops, with cycle detection. |

### Features implemented

- **Reltable exclusion** — `<reltable>` blocks stripped before key/scope extraction (DITA spec §2.4.4)
- **Scope-qualified keys** — keys stored as both `keyName` and `scope.keyName`
- **`@keys` on keyscoped maprefs** — registered in the child scope (DITA spec §2.4.4.1)
- **Inline scope branches** — `@keyscope` on non-map `<topicref>` elements creates child scopes recursively
- **Context-aware resolution** — `resolveKey()` checks `topicToScope` to prefer scope-qualified lookups for files inside a named scope
- **Duplicate key tracking** — `duplicateKeys` map records all definitions for keys defined more than once
- **Subject scheme discovery** — `subjectSchemePaths` collected during BFS

### Bug fixes

- `findInnerContent`: self-closing same-name elements no longer incorrectly increment the nesting depth counter
- `server/tsconfig.json`: added `ignoreDeprecations: 5.0` to suppress TS5107 deprecation warning in TypeScript 5.5+

https://claude.ai/code/session_01BGgjc9YXztUB9wCPRxTpk6