### PR TITLE
[fix]: auto-refresh HTML5 preview on save (#96)

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -10,7 +10,7 @@ export {
     resetValidationRateLimiter
 } from './validateCommand';
 export { publishCommand, publishHTML5Command } from './publishCommand';
-export { previewHTML5Command, initializePreview } from './previewCommand';
+export { previewHTML5Command, initializePreview, shouldAutoRefreshPreview } from './previewCommand';
 export { newTopicCommand, newMapCommand, newBookmapCommand } from './fileCreationCommands';
 export { configureDitaOTCommand } from './configureCommand';
 export { setupCSpellCommand } from './cspellSetupCommand';

--- a/src/commands/previewCommand.ts
+++ b/src/commands/previewCommand.ts
@@ -23,8 +23,13 @@ export function initializePreview(context: vscode.ExtensionContext): void {
 /**
  * Command: ditacraft.previewHTML5
  * Shows HTML5 preview in WebView panel
+ *
+ * @param uri Optional file URI; falls back to the active editor.
+ * @param preserveFocus When true, the preview panel is revealed without
+ *        stealing focus from the editor. Used by the save-triggered
+ *        auto-refresh so the cursor stays in the document.
  */
-export async function previewHTML5Command(uri?: vscode.Uri): Promise<void> {
+export async function previewHTML5Command(uri?: vscode.Uri, preserveFocus = false): Promise<void> {
     try {
         // Get and validate file URI
         const fileUri = await getAndValidateFileUri(uri);
@@ -43,11 +48,45 @@ export async function previewHTML5Command(uri?: vscode.Uri): Promise<void> {
         const outputDir = await generateHtml5OutputIfNeeded(ditaOt, filePath);
 
         // Find and display the main HTML file
-        await displayPreview(filePath, outputDir);
+        await displayPreview(filePath, outputDir, preserveFocus);
 
     } catch (error) {
         handlePreviewError(error);
     }
+}
+
+/**
+ * Decide whether a save should trigger an auto-refresh of the preview.
+ * Exported for testing.
+ *
+ * Refresh only when the setting is enabled AND the saved file is the same
+ * source file currently shown in the preview panel. Paths are normalized and
+ * compared case-insensitively on case-insensitive platforms (Windows/macOS),
+ * so a tree-view URI (`c:\…`) and an editor document URI (`C:\…`) still match.
+ */
+export function shouldAutoRefreshPreview(
+    savedFilePath: string,
+    autoRefreshEnabled: boolean,
+    previewedSourceFile: string | undefined
+): boolean {
+    if (!autoRefreshEnabled || previewedSourceFile === undefined) {
+        return false;
+    }
+    return pathsEqual(savedFilePath, previewedSourceFile);
+}
+
+/**
+ * Compare two file system paths for equality, accounting for separator
+ * normalization and platform case-sensitivity.
+ */
+function pathsEqual(a: string, b: string): boolean {
+    const normA = path.normalize(a);
+    const normB = path.normalize(b);
+    // Windows and macOS file systems are case-insensitive; Linux is not.
+    if (process.platform === 'win32' || process.platform === 'darwin') {
+        return normA.toLowerCase() === normB.toLowerCase();
+    }
+    return normA === normB;
 }
 
 /**
@@ -195,7 +234,7 @@ async function generateHtml5OutputIfNeeded(ditaOt: DitaOtWrapper, filePath: stri
 /**
  * Display the preview in WebView panel or external browser
  */
-async function displayPreview(sourceFilePath: string, outputDir: string): Promise<void> {
+async function displayPreview(sourceFilePath: string, outputDir: string, preserveFocus = false): Promise<void> {
     const fileName = path.basename(sourceFilePath, path.extname(sourceFilePath));
 
     // Find the main HTML file (P1-1 Fix: await async function)
@@ -210,7 +249,8 @@ async function displayPreview(sourceFilePath: string, outputDir: string): Promis
         DitaPreviewPanel.createOrShow(
             extensionContext.extensionUri,
             htmlFile,
-            sourceFilePath
+            sourceFilePath,
+            preserveFocus
         );
         logger.info('Preview panel opened', { htmlFile, sourceFile: sourceFilePath });
     } else {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,6 +19,7 @@ import {
     publishHTML5Command,
     previewHTML5Command,
     initializePreview,
+    shouldAutoRefreshPreview,
     newTopicCommand,
     newMapCommand,
     newBookmapCommand,
@@ -26,7 +27,7 @@ import {
     setupCSpellCommand,
     validateGuideCommand
 } from './commands';
-import { registerPreviewPanelSerializer } from './providers/previewPanel';
+import { registerPreviewPanelSerializer, DitaPreviewPanel } from './providers/previewPanel';
 import { disposeDitaOtDiagnostics } from './utils/ditaOtErrorParser';
 import { UI_TIMEOUTS } from './utils/constants';
 import { getDitaOtOutputChannel, disposeDitaOtOutputChannel } from './utils/ditaOtOutputChannel';
@@ -78,6 +79,7 @@ export function activate(context: vscode.ExtensionContext) {
         outputChannel.appendLine('Initializing preview panel...');
         initializePreview(context);
         registerPreviewPanelSerializer(context);
+        registerPreviewAutoRefresh(context);
         outputChannel.appendLine('Preview panel initialized');
 
         // Note: Document links now provided by the LSP server (Phase 6)
@@ -505,6 +507,87 @@ export async function deactivate(): Promise<void> {
     }
 
     try { logger.dispose(); } catch { /* may not be initialized */ }
+}
+
+/** Debounce delay before a save triggers a preview re-publish (ms). */
+const PREVIEW_AUTO_REFRESH_DEBOUNCE_MS = 500;
+
+/**
+ * Register the save-triggered auto-refresh for the HTML5 preview.
+ *
+ * When `ditacraft.previewAutoRefresh` is enabled and the saved document is the
+ * source file currently shown in the preview panel, re-run the preview command
+ * so DITA-OT regenerates the output (the source is now newer than the cached
+ * HTML) and the panel updates. Focus is preserved so the cursor stays in the
+ * editor. Resolves issue #96.
+ *
+ * Rapid saves (auto-save, fast Ctrl+S) are coalesced: a short debounce drops
+ * redundant triggers, and refreshes are serialized so at most one DITA-OT
+ * publish runs at a time against the shared output directory. A save that
+ * arrives while a publish is in flight schedules exactly one trailing refresh.
+ */
+function registerPreviewAutoRefresh(context: vscode.ExtensionContext): void {
+    let debounceTimer: NodeJS.Timeout | undefined;
+    let refreshInFlight = false;
+    let pendingUri: vscode.Uri | undefined;
+
+    const runRefresh = (uri: vscode.Uri): void => {
+        refreshInFlight = true;
+        logger.debug('Auto-refreshing preview after save', { file: uri.fsPath });
+        fireAndForget(
+            previewHTML5Command(uri, /* preserveFocus */ true).finally(() => {
+                refreshInFlight = false;
+                // Replay the most recent save that landed during this publish.
+                if (pendingUri) {
+                    const next = pendingUri;
+                    pendingUri = undefined;
+                    runRefresh(next);
+                }
+            }),
+            'preview-auto-refresh'
+        );
+    };
+
+    const saveListener = vscode.workspace.onDidSaveTextDocument(document => {
+        const panel = DitaPreviewPanel.currentPanel;
+        if (!panel) {
+            return;
+        }
+
+        if (!shouldAutoRefreshPreview(
+            document.uri.fsPath,
+            configManager.get('previewAutoRefresh'),
+            panel.getSourceFile()
+        )) {
+            return;
+        }
+
+        const uri = document.uri;
+
+        // A publish is already running — remember this save and replay it once
+        // the current run finishes, rather than launching a concurrent publish.
+        if (refreshInFlight) {
+            pendingUri = uri;
+            return;
+        }
+
+        if (debounceTimer) {
+            clearTimeout(debounceTimer);
+        }
+        debounceTimer = setTimeout(() => {
+            debounceTimer = undefined;
+            runRefresh(uri);
+        }, PREVIEW_AUTO_REFRESH_DEBOUNCE_MS);
+    });
+
+    context.subscriptions.push(saveListener, {
+        dispose: () => {
+            if (debounceTimer) {
+                clearTimeout(debounceTimer);
+                debounceTimer = undefined;
+            }
+        }
+    });
 }
 
 /**

--- a/src/providers/previewPanel.ts
+++ b/src/providers/previewPanel.ts
@@ -44,13 +44,19 @@ export class DitaPreviewPanel {
     public static createOrShow(
         extensionUri: vscode.Uri,
         htmlFile: string,
-        sourceFile: string
+        sourceFile: string,
+        preserveFocus = false
     ): DitaPreviewPanel {
         const column = vscode.ViewColumn.Beside;
 
-        // If we already have a panel, show it
+        // If we already have a panel, refresh its content.
         if (DitaPreviewPanel.currentPanel) {
-            DitaPreviewPanel.currentPanel._panel.reveal(column);
+            // Auto-refresh (preserveFocus) updates content in place without
+            // pulling the preview tab to the foreground; the manual command
+            // reveals it so the user sees the panel they just invoked.
+            if (!preserveFocus) {
+                DitaPreviewPanel.currentPanel._panel.reveal(column);
+            }
             DitaPreviewPanel.currentPanel.update(htmlFile, sourceFile);
             return DitaPreviewPanel.currentPanel;
         }
@@ -59,7 +65,7 @@ export class DitaPreviewPanel {
         const panel = vscode.window.createWebviewPanel(
             DitaPreviewPanel.viewType,
             'DITA Preview',
-            column,
+            { viewColumn: column, preserveFocus },
             {
                 enableScripts: true,
                 retainContextWhenHidden: true,

--- a/src/test/suite/previewCommand.test.ts
+++ b/src/test/suite/previewCommand.test.ts
@@ -10,7 +10,8 @@ import * as fs from 'fs';
 import {
     validateFilePath,
     findMainHtmlFile,
-    initializePreview
+    initializePreview,
+    shouldAutoRefreshPreview
 } from '../../commands/previewCommand';
 
 suite('Preview Command Test Suite', () => {
@@ -256,6 +257,61 @@ suite('Preview Command Test Suite', () => {
 
             assert.ok(customCss !== undefined, 'previewCustomCss should be defined');
             assert.strictEqual(typeof customCss, 'string', 'previewCustomCss should be string');
+        });
+    });
+
+    suite('Auto-Refresh on Save (issue #96)', () => {
+        const savedFile = path.join('C:', 'docs', 'topic.dita');
+
+        test('Should refresh when enabled and saved file is the previewed source', function() {
+            assert.strictEqual(
+                shouldAutoRefreshPreview(savedFile, true, savedFile),
+                true
+            );
+        });
+
+        test('Should not refresh when the setting is disabled', function() {
+            assert.strictEqual(
+                shouldAutoRefreshPreview(savedFile, false, savedFile),
+                false
+            );
+        });
+
+        test('Should not refresh when no preview panel is open (no source file)', function() {
+            assert.strictEqual(
+                shouldAutoRefreshPreview(savedFile, true, undefined),
+                false
+            );
+        });
+
+        test('Should not refresh when a different file is saved', function() {
+            const otherFile = path.join('C:', 'docs', 'other.dita');
+            assert.strictEqual(
+                shouldAutoRefreshPreview(otherFile, true, savedFile),
+                false
+            );
+        });
+
+        test('Should match paths that differ only by normalization', function() {
+            const a = path.join('C:', 'docs', 'topic.dita');
+            const b = path.join('C:', 'docs', '.', 'sub', '..', 'topic.dita');
+            assert.strictEqual(
+                shouldAutoRefreshPreview(a, true, b),
+                true
+            );
+        });
+
+        test('Should match case-insensitively on Windows/macOS (drive-letter casing)', function() {
+            if (process.platform !== 'win32' && process.platform !== 'darwin') {
+                this.skip();
+                return;
+            }
+            const previewed = path.join('C:', 'Docs', 'Topic.dita');
+            const saved = path.join('c:', 'docs', 'topic.dita');
+            assert.strictEqual(
+                shouldAutoRefreshPreview(saved, true, previewed),
+                true
+            );
         });
     });
 });


### PR DESCRIPTION
previewAutoRefresh was read into config but never consumed — no save listener triggered a preview refresh, so the panel only updated on a manual Preview HTML5 invocation.

Wire workspace.onDidSaveTextDocument to re-run the preview command when the setting is enabled and the saved file is the previewed source. The refresh:
- preserves editor focus and updates the panel in place (no foreground reveal) so editing is undisturbed;
- debounces rapid saves (500ms) and serializes refreshes so only one DITA-OT publish runs at a time against the shared output directory, with a single trailing replay for a save that lands mid-publish;
- matches paths case-insensitively on Windows/macOS so it works whether the preview was opened from the editor or the file tree.

Adds unit tests for the shouldAutoRefreshPreview decision logic.