### PR TITLE
Fix LSP path-traversal guard gaps, key-space diamond scope loss, and content-model tag desync

### DIFF
--- a/mcp/src/tools/ditaMapStructure.ts
+++ b/mcp/src/tools/ditaMapStructure.ts
@@ -27,7 +27,7 @@ export function handleDitaMapStructure(
         includeMetadata: includeMetadata ?? true,
     };
 
-    const graph = handleGetContextGraph(params);
+    const graph = handleGetContextGraph(params, ctx.keySpaceService);
 
     if (format === 'tree') {
         return formatAsTree(graph);

--- a/mcp/test/tools/ditaMapStructure.test.ts
+++ b/mcp/test/tools/ditaMapStructure.test.ts
@@ -1,4 +1,7 @@
 import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import { createTestWorkspace, TestWorkspace } from '../helper';
 
 const MAP_WITH_TOPICS = [
@@ -77,6 +80,38 @@ suite('dita_map_structure', () => {
         const text = result.content[0]?.text ?? '';
         const parsed = JSON.parse(text);
         assert.ok(parsed.rootMap);
+    });
+
+    test('topicref escaping the workspace is not resolved into a child (regression)', async () => {
+        // A submap reachable from test-map.ditamap references a path that
+        // escapes the workspace root entirely. The map-structure tool must
+        // not resolve or report on files outside the workspace, mirroring
+        // the guard already verified for handleGetContextGraph directly in
+        // server/test/contextGraph.test.ts.
+        const outsideFile = path.join(os.tmpdir(), 'ditacraft-mcp-outside.dita');
+        fs.writeFileSync(outsideFile, '<topic id="o"><title>Outside</title></topic>');
+        const escapeMapPath = path.join(ws.dir, 'escape-map.ditamap');
+        const relativeHref = path.relative(path.dirname(escapeMapPath), outsideFile).replace(/\\/g, '/');
+        fs.writeFileSync(escapeMapPath, [
+            '<?xml version="1.0" encoding="UTF-8"?>',
+            '<!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">',
+            '<map>',
+            '  <title>Escape Map</title>',
+            `  <topicref href="${relativeHref}"/>`,
+            '</map>',
+        ].join('\n'));
+
+        try {
+            const result = await ws.callToolRaw('dita_map_structure', { mapUri: 'escape-map.ditamap' });
+            const text = result.content[0]?.text ?? '';
+            const parsed = JSON.parse(text);
+            assert.strictEqual(parsed.rootMap.children.length, 0,
+                'escaping topicref must not be resolved into a child');
+            assert.strictEqual(parsed.topics.length, 0,
+                'no topic outside the workspace should be indexed');
+        } finally {
+            fs.rmSync(outsideFile, { force: true });
+        }
     });
 
 });

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ditacraft-lsp-server",
-  "version": "0.7.3",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ditacraft-lsp-server",
-      "version": "0.7.3",
+      "version": "0.8.1",
       "dependencies": {
         "fast-xml-parser": "^5.5.12",
         "salve-annos": "^1.2.4",

--- a/server/src/features/circularRefDetection.ts
+++ b/server/src/features/circularRefDetection.ts
@@ -10,7 +10,9 @@ import { Diagnostic, DiagnosticSeverity } from 'vscode-languageserver/node';
 import * as path from 'path';
 import { promises as fsp } from 'fs';
 import { t } from '../utils/i18n';
-import { normalizeFsPath, offsetToRange, stripCommentsAndCDATA, uriToPath } from '../utils/textUtils';
+import {
+    normalizeFsPath, offsetToRange, stripCommentsAndCDATA, uriToPath, isPathWithinWorkspace,
+} from '../utils/textUtils';
 
 const SOURCE = 'dita-lsp';
 
@@ -42,12 +44,13 @@ const CONREF_REGEX = /\bconref\s*=\s*["']([^"'#]+)/g;
 export async function detectCircularReferences(
     text: string,
     documentUri: string,
+    workspaceFolders: readonly string[] = [],
 ): Promise<Diagnostic[]> {
     const filePath = uriToPath(documentUri);
     const currentDir = path.dirname(filePath);
     const diagnostics: Diagnostic[] = [];
 
-    const refs = extractFileReferences(text, currentDir);
+    const refs = extractFileReferences(text, currentDir, workspaceFolders);
     const normalizedSelf = normalizePath(filePath);
 
     // Cache file contents to avoid re-reading the same file from multiple DFS paths
@@ -60,7 +63,7 @@ export async function detectCircularReferences(
         const pathList: string[] = [normalizedSelf];
 
         const cyclePath = await dfsDetectAnyCycle(
-            ref.targetPath, pathStack, pathList, fileCache
+            ref.targetPath, pathStack, pathList, fileCache, workspaceFolders
         );
 
         if (cyclePath) {
@@ -91,7 +94,9 @@ interface FileRef {
 /** Extract structural file references from text, resolving paths relative to baseDir.
  *  Only follows topicref/mapref/chapter/etc. href (not keydef, xref, link, coderef)
  *  and conref attributes on any element. */
-function extractFileReferences(text: string, baseDir: string): FileRef[] {
+function extractFileReferences(
+    text: string, baseDir: string, workspaceFolders: readonly string[]
+): FileRef[] {
     const refs: FileRef[] = [];
     // Strip comments and CDATA to avoid false matches
     const cleanText = stripCommentsAndCDATA(text);
@@ -101,7 +106,7 @@ function extractFileReferences(text: string, baseDir: string): FileRef[] {
     const structuralRegex = new RegExp(STRUCTURAL_REF_REGEX.source, STRUCTURAL_REF_REGEX.flags);
     while ((match = structuralRegex.exec(cleanText)) !== null) {
         const refValue = match[2];
-        const ref = resolveRef(refValue, baseDir, text, match);
+        const ref = resolveRef(refValue, baseDir, text, match, workspaceFolders);
         if (ref) refs.push(ref);
     }
 
@@ -109,7 +114,7 @@ function extractFileReferences(text: string, baseDir: string): FileRef[] {
     const conrefRegex = new RegExp(CONREF_REGEX.source, CONREF_REGEX.flags);
     while ((match = conrefRegex.exec(cleanText)) !== null) {
         const refValue = match[1];
-        const ref = resolveRef(refValue, baseDir, text, match);
+        const ref = resolveRef(refValue, baseDir, text, match, workspaceFolders);
         if (ref) refs.push(ref);
     }
 
@@ -117,7 +122,10 @@ function extractFileReferences(text: string, baseDir: string): FileRef[] {
 }
 
 /** Resolve a reference value to a FileRef, or null if it should be skipped. */
-function resolveRef(refValue: string, baseDir: string, text: string, match: RegExpExecArray): FileRef | null {
+function resolveRef(
+    refValue: string, baseDir: string, text: string, match: RegExpExecArray,
+    workspaceFolders: readonly string[]
+): FileRef | null {
     // Skip external URLs
     if (/^https?:\/\/|^mailto:|^ftp:\/\//.test(refValue)) return null;
     // Skip empty values
@@ -126,6 +134,8 @@ function resolveRef(refValue: string, baseDir: string, text: string, match: RegE
     const targetPath = path.resolve(baseDir, refValue);
     // Only consider DITA files (not generic .xml)
     if (!isDitaFile(targetPath)) return null;
+    // Never follow a reference that resolves outside the workspace
+    if (!isPathWithinWorkspace(targetPath, workspaceFolders)) return null;
 
     const range = offsetToRange(text, match.index, match.index + match[0].length);
     return { targetPath: normalizePath(targetPath), range };
@@ -148,6 +158,7 @@ async function dfsDetectAnyCycle(
     pathStack: Set<string>,
     pathList: string[],
     fileCache: Map<string, string | null>,
+    workspaceFolders: readonly string[],
 ): Promise<string[] | null> {
     // Safety depth limit to prevent stack overflow on pathological hierarchies
     if (pathList.length >= MAX_DEPTH) return null;
@@ -180,11 +191,11 @@ async function dfsDetectAnyCycle(
     pathList.push(normalized);
 
     const dir = path.dirname(currentFile);
-    const refs = extractFileReferences(content, dir);
+    const refs = extractFileReferences(content, dir, workspaceFolders);
 
     for (const ref of refs) {
         const cycle = await dfsDetectAnyCycle(
-            ref.targetPath, pathStack, pathList, fileCache
+            ref.targetPath, pathStack, pathList, fileCache, workspaceFolders
         );
         if (cycle) {
             pathStack.delete(normalized);

--- a/server/src/features/codeActions.ts
+++ b/server/src/features/codeActions.ts
@@ -382,11 +382,18 @@ function fixDeprecatedAltAttr(
     text: string,
     document: TextDocument
 ): CodeAction[] {
-    const startOffset = document.offsetAt(diagnostic.range.start);
-    const textAtPos = text.slice(startOffset);
+    // The diagnostic range points at the alt="..." attribute itself (see
+    // DITA-SCH-011 in ditaRulesValidator.ts), not at the <image tag start.
+    // Search backward for the enclosing tag rather than forward from the
+    // attribute — searching forward would skip past this tag entirely and
+    // match the *next* <image> element in the document instead.
+    const diagnosticOffset = document.offsetAt(diagnostic.range.start);
+    const tagStart = text.lastIndexOf('<image', diagnosticOffset);
+    if (tagStart === -1) return [];
+    const textFromTagStart = text.slice(tagStart);
 
     // Find the <image> tag and extract alt attribute value
-    const imageMatch = textAtPos.match(/<image\b([^>]*)/);
+    const imageMatch = textFromTagStart.match(/<image\b([^>]*)/);
     if (!imageMatch) return [];
 
     const attrs = imageMatch[1];
@@ -396,7 +403,7 @@ function fixDeprecatedAltAttr(
     const altValue = altMatch[1];
 
     // Remove the alt attribute from the tag
-    const altAttrStart = startOffset + imageMatch[0].indexOf(altMatch[0]);
+    const altAttrStart = tagStart + imageMatch[0].indexOf(altMatch[0]);
     const altAttrEnd = altAttrStart + altMatch[0].length;
 
     // Also remove leading space before the attribute
@@ -406,7 +413,7 @@ function fixDeprecatedAltAttr(
     }
 
     // Find where to insert the <alt> element — after the image opening tag
-    const tagEnd = text.indexOf('>', startOffset);
+    const tagEnd = text.indexOf('>', tagStart);
     if (tagEnd === -1) return [];
 
     const isSelfClosing = text[tagEnd - 1] === '/';

--- a/server/src/features/completion.ts
+++ b/server/src/features/completion.ts
@@ -25,7 +25,7 @@ import {
 import { KeySpaceService } from '../services/keySpaceService';
 import { SubjectSchemeService } from '../services/subjectSchemeService';
 import { TOPIC_TYPE_NAMES } from '../data/ditaSpecialization';
-import { uriToPath, isPathWithinWorkspace } from '../utils/textUtils';
+import { uriToPath, isPathWithinWorkspace, effectiveWorkspaceFolders } from '../utils/textUtils';
 
 const enum Context {
     ElementName,
@@ -330,7 +330,9 @@ async function getAttributeValueCompletions(
 
     // --- Href / Conref completion ---
     if (attrName === 'href' || attrName === 'conref') {
-        const workspaceFolders = keySpaceService?.getWorkspaceFolders() ?? [];
+        const workspaceFolders = effectiveWorkspaceFolders(
+            uriToPath(documentUri), keySpaceService?.getWorkspaceFolders() ?? []
+        );
         if (ctx.prefix.includes('#')) {
             // Fragment completion: topic/element IDs in target file
             return getHrefFragmentCompletions(ctx, documentUri, workspaceFolders);

--- a/server/src/features/completion.ts
+++ b/server/src/features/completion.ts
@@ -144,10 +144,15 @@ function findParentElement(text: string, beforePos: number): string {
 
         const tagName = match[1];
         if (match[0].startsWith('</')) {
-            // Closing tag — pop from stack
+            // Closing tag — pop from stack, discarding this entry and every
+            // intervening never-closed entry above it too (same stack-desync
+            // bug class fixed in contentModelValidation.ts, symbols.ts, and
+            // folding.ts: removing only the matched entry would leave stale
+            // ancestors on the stack and corrupt the parent lookup for the
+            // rest of the document).
             const idx = stack.lastIndexOf(tagName);
             if (idx >= 0) {
-                stack.splice(idx, 1);
+                stack.splice(idx);
             }
         } else {
             // Opening tag — check if self-closing

--- a/server/src/features/completion.ts
+++ b/server/src/features/completion.ts
@@ -26,6 +26,7 @@ import { KeySpaceService } from '../services/keySpaceService';
 import { SubjectSchemeService } from '../services/subjectSchemeService';
 import { TOPIC_TYPE_NAMES } from '../data/ditaSpecialization';
 import { uriToPath, isPathWithinWorkspace, effectiveWorkspaceFolders } from '../utils/textUtils';
+import { resyncStackToMatch } from '../utils/tagStack';
 
 const enum Context {
     ElementName,
@@ -150,10 +151,7 @@ function findParentElement(text: string, beforePos: number): string {
             // folding.ts: removing only the matched entry would leave stale
             // ancestors on the stack and corrupt the parent lookup for the
             // rest of the document).
-            const idx = stack.lastIndexOf(tagName);
-            if (idx >= 0) {
-                stack.splice(idx);
-            }
+            resyncStackToMatch(stack, tagName, name => name);
         } else {
             // Opening tag — check if self-closing
             const closeAngle = text.indexOf('>', match.index);

--- a/server/src/features/completion.ts
+++ b/server/src/features/completion.ts
@@ -25,7 +25,7 @@ import {
 import { KeySpaceService } from '../services/keySpaceService';
 import { SubjectSchemeService } from '../services/subjectSchemeService';
 import { TOPIC_TYPE_NAMES } from '../data/ditaSpecialization';
-import { uriToPath } from '../utils/textUtils';
+import { uriToPath, isPathWithinWorkspace } from '../utils/textUtils';
 
 const enum Context {
     ElementName,
@@ -325,12 +325,13 @@ async function getAttributeValueCompletions(
 
     // --- Href / Conref completion ---
     if (attrName === 'href' || attrName === 'conref') {
+        const workspaceFolders = keySpaceService?.getWorkspaceFolders() ?? [];
         if (ctx.prefix.includes('#')) {
             // Fragment completion: topic/element IDs in target file
-            return getHrefFragmentCompletions(ctx, documentUri);
+            return getHrefFragmentCompletions(ctx, documentUri, workspaceFolders);
         }
         // File path completion: list .dita/.ditamap files relative to current doc
-        return getHrefFileCompletions(ctx, documentUri);
+        return getHrefFileCompletions(ctx, documentUri, workspaceFolders);
     }
 
     // --- Subject scheme controlled values ---
@@ -461,7 +462,8 @@ async function getKeyrefCompletions(
  */
 async function getHrefFragmentCompletions(
     ctx: CompletionContext,
-    documentUri: string
+    documentUri: string,
+    workspaceFolders: readonly string[]
 ): Promise<CompletionItem[]> {
     const currentValue = ctx.prefix;
     const hashPos = currentValue.indexOf('#');
@@ -473,6 +475,8 @@ async function getHrefFragmentCompletions(
     const targetPath = filePart
         ? path.resolve(currentDir, filePart)
         : currentFilePath; // same-file reference
+
+    if (!isPathWithinWorkspace(targetPath, workspaceFolders)) return [];
 
     let targetContent: string;
     try {
@@ -516,7 +520,8 @@ const MAX_DIR_ENTRIES = 200;
  */
 async function getHrefFileCompletions(
     ctx: CompletionContext,
-    documentUri: string
+    documentUri: string,
+    workspaceFolders: readonly string[]
 ): Promise<CompletionItem[]> {
     const currentFilePath = uriToPath(documentUri);
     const currentDir = path.dirname(currentFilePath);
@@ -534,6 +539,8 @@ async function getHrefFileCompletions(
     } else {
         searchDir = currentDir;
     }
+
+    if (!isPathWithinWorkspace(searchDir, workspaceFolders)) return [];
 
     let entries: Dirent[];
     try {

--- a/server/src/features/contentModelValidation.ts
+++ b/server/src/features/contentModelValidation.ts
@@ -12,6 +12,7 @@
  */
 
 import { Diagnostic, DiagnosticSeverity, Range } from 'vscode-languageserver/node';
+import { resyncStackToMatch } from '../utils/tagStack';
 
 // ---------------------------------------------------------------------------
 // Content model definitions
@@ -309,14 +310,6 @@ interface XmlElement {
     column: number;
 }
 
-/** Find the topmost stack entry with the given name, searching from the top down. */
-function findLastIndexByName(stack: XmlElement[], name: string): number {
-    for (let i = stack.length - 1; i >= 0; i--) {
-        if (stack[i].name === name) return i;
-    }
-    return -1;
-}
-
 /**
  * Parse XML text into a lightweight element tree.
  * This is NOT a full XML parser — it only extracts element nesting for
@@ -382,10 +375,7 @@ function parseElementTree(content: string): { root: XmlElement | null; parseDiag
                     // instead of blindly popping, which would desync the tree
                     // for the rest of the document. If no ancestor matches,
                     // treat this as a stray closing tag and leave the stack intact.
-                    const matchIdx = findLastIndexByName(stack, tagName);
-                    if (matchIdx >= 0) {
-                        stack.length = matchIdx;
-                    }
+                    resyncStackToMatch(stack, tagName, e => e.name);
                 } else {
                     stack.pop();
                 }

--- a/server/src/features/contentModelValidation.ts
+++ b/server/src/features/contentModelValidation.ts
@@ -309,6 +309,14 @@ interface XmlElement {
     column: number;
 }
 
+/** Find the topmost stack entry with the given name, searching from the top down. */
+function findLastIndexByName(stack: XmlElement[], name: string): number {
+    for (let i = stack.length - 1; i >= 0; i--) {
+        if (stack[i].name === name) return i;
+    }
+    return -1;
+}
+
 /**
  * Parse XML text into a lightweight element tree.
  * This is NOT a full XML parser — it only extracts element nesting for
@@ -369,8 +377,18 @@ function parseElementTree(content: string): { root: XmlElement | null; parseDiag
                         'DITA-CM-PARSE',
                         'dita-lsp',
                     ));
+
+                    // Resync: close back through the nearest matching ancestor
+                    // instead of blindly popping, which would desync the tree
+                    // for the rest of the document. If no ancestor matches,
+                    // treat this as a stray closing tag and leave the stack intact.
+                    const matchIdx = findLastIndexByName(stack, tagName);
+                    if (matchIdx >= 0) {
+                        stack.length = matchIdx;
+                    }
+                } else {
+                    stack.pop();
                 }
-                stack.pop();
             }
         } else {
             const element: XmlElement = { name: tagName, children: [], line: pos.line, column: pos.column };

--- a/server/src/features/contentModelValidation.ts
+++ b/server/src/features/contentModelValidation.ts
@@ -194,8 +194,8 @@ const DITA_CONTENT_MODELS: Record<string, ContentModel> = {
     'body': {
         allowedChildren: [
             // basic.block
-            'p', 'ul', 'ol', 'sl', 'dl', 'pre', 'codeblock', 'msgblock',
-            'lines', 'lq', 'note', 'hazardstatement', 'image', 'object',
+            'p', 'ul', 'ol', 'sl', 'dl', 'parml', 'pre', 'codeblock', 'msgblock',
+            'screen', 'syntaxdiagram', 'lines', 'lq', 'note', 'hazardstatement', 'image', 'object',
             'fig', 'table', 'simpletable', 'div',
             // body-specific
             'section', 'example', 'bodydiv', 'sectiondiv',
@@ -213,7 +213,7 @@ const DITA_CONTENT_MODELS: Record<string, ContentModel> = {
         allowedChildren: [
             // basic.block
             'p', 'ul', 'ol', 'sl', 'dl', 'pre', 'codeblock', 'msgblock',
-            'lines', 'lq', 'note', 'hazardstatement', 'image', 'object',
+            'screen', 'lines', 'lq', 'note', 'hazardstatement', 'image', 'object',
             'fig', 'table', 'simpletable', 'div',
             // conbody-specific
             'section', 'example', 'bodydiv', 'sectiondiv', 'conbodydiv',
@@ -255,8 +255,8 @@ const DITA_CONTENT_MODELS: Record<string, ContentModel> = {
             // section.cnt = basic.block + basic.ph + title + sectiondiv + txt.incl + data + foreign
             'title',
             // basic.block
-            'p', 'ul', 'ol', 'sl', 'dl', 'pre', 'codeblock', 'msgblock',
-            'lines', 'lq', 'note', 'hazardstatement', 'image', 'object',
+            'p', 'ul', 'ol', 'sl', 'dl', 'parml', 'pre', 'codeblock', 'msgblock',
+            'screen', 'syntaxdiagram', 'lines', 'lq', 'note', 'hazardstatement', 'image', 'object',
             'fig', 'table', 'simpletable', 'div', 'sectiondiv',
             // txt.incl
             'draft-comment', 'required-cleanup', 'fn', 'indexterm', 'indextermref',

--- a/server/src/features/contextGraph.ts
+++ b/server/src/features/contextGraph.ts
@@ -9,7 +9,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { IKeySpaceService } from '../services/interfaces';
-import { uriToPath, isPathWithinWorkspace } from '../utils/textUtils';
+import { uriToPath, isPathWithinWorkspace, effectiveWorkspaceFolders } from '../utils/textUtils';
 import { URI } from 'vscode-uri';
 
 // ── Request / Response types (mirrored on the client) ─────────────────────
@@ -232,7 +232,7 @@ export function handleGetContextGraph(
 ): ContextGraph {
     const mapPath = uriToPath(params.uri);
     const maxDepth = params.depth ?? 3;
-    const workspaceFolders = keySpaceService?.getWorkspaceFolders() ?? [];
+    const workspaceFolders = effectiveWorkspaceFolders(mapPath, keySpaceService?.getWorkspaceFolders() ?? []);
 
     const topicsMap = new Map<string, TopicNode>();
     const relations: RelationNode[] = [];

--- a/server/src/features/contextGraph.ts
+++ b/server/src/features/contextGraph.ts
@@ -9,7 +9,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { IKeySpaceService } from '../services/interfaces';
-import { uriToPath } from '../utils/textUtils';
+import { uriToPath, isPathWithinWorkspace } from '../utils/textUtils';
 import { URI } from 'vscode-uri';
 
 // ── Request / Response types (mirrored on the client) ─────────────────────
@@ -105,7 +105,7 @@ function countElements(filePath: string): number {
     }
 }
 
-function resolveHref(href: string, baseDir: string): string | null {
+function resolveHref(href: string, baseDir: string, workspaceFolders: readonly string[]): string | null {
     if (!href || href.startsWith('http://') || href.startsWith('https://')) {
         return null;
     }
@@ -121,6 +121,10 @@ function resolveHref(href: string, baseDir: string): string | null {
     if (upCount > 8) { return null; }
 
     const resolved = path.resolve(baseDir, normalized);
+    // Hard boundary check — the upward-traversal count above is only a
+    // heuristic and does not guarantee the resolved path stays inside the
+    // workspace (e.g. a deeply nested workspace root vs. a shallow one).
+    if (!isPathWithinWorkspace(resolved, workspaceFolders)) { return null; }
     return fs.existsSync(resolved) ? resolved : null;
 }
 
@@ -132,7 +136,8 @@ function buildMapNode(
     visited: Set<string>,
     topics: Map<string, TopicNode>,
     relations: RelationNode[],
-    keyDefs: Map<string, KeyDef>
+    keyDefs: Map<string, KeyDef>,
+    workspaceFolders: readonly string[]
 ): MapNode {
     const node: MapNode = {
         uri: URI.file(mapPath).toString(),
@@ -160,7 +165,7 @@ function buildMapNode(
         const hrefMatch = attrs.match(/href="([^"]*)"/);
         if (!hrefMatch) { continue; }
         const href = hrefMatch[1];
-        const resolved = resolveHref(href, path.dirname(mapPath));
+        const resolved = resolveHref(href, path.dirname(mapPath), workspaceFolders);
         if (!resolved) { continue; }
 
         const fromUri = URI.file(mapPath).toString();
@@ -169,7 +174,10 @@ function buildMapNode(
 
         if (isMap) {
             relations.push({ fromUri, toUri, relType: 'mapref' });
-            const child = buildMapNode(resolved, path.dirname(resolved), depth + 1, maxDepth, visited, topics, relations, keyDefs);
+            const child = buildMapNode(
+                resolved, path.dirname(resolved), depth + 1, maxDepth, visited, topics, relations,
+                keyDefs, workspaceFolders
+            );
             node.children.push(child);
         } else {
             relations.push({ fromUri, toUri, relType: 'topicref' });
@@ -220,10 +228,11 @@ function buildMapNode(
 
 export function handleGetContextGraph(
     params: GetContextGraphParams,
-    _keySpaceService?: IKeySpaceService
+    keySpaceService?: IKeySpaceService
 ): ContextGraph {
     const mapPath = uriToPath(params.uri);
     const maxDepth = params.depth ?? 3;
+    const workspaceFolders = keySpaceService?.getWorkspaceFolders() ?? [];
 
     const topicsMap = new Map<string, TopicNode>();
     const relations: RelationNode[] = [];
@@ -238,7 +247,8 @@ export function handleGetContextGraph(
         visited,
         topicsMap,
         relations,
-        keyDefsMap
+        keyDefsMap,
+        workspaceFolders
     );
 
     const topics = Array.from(topicsMap.values());

--- a/server/src/features/crossRefValidation.ts
+++ b/server/src/features/crossRefValidation.ts
@@ -14,7 +14,7 @@ import { TOPIC_TYPE_NAMES, MAP_TYPE_NAMES } from '../data/ditaSpecialization';
 import { t } from '../utils/i18n';
 import {
     stripCommentsAndCodeContent, offsetToRange, escapeRegex, normalizeFsPath, uriToPath,
-    isPathWithinWorkspace,
+    isPathWithinWorkspace, effectiveWorkspaceFolders,
 } from '../utils/textUtils';
 
 const SOURCE = 'dita-lsp';
@@ -51,7 +51,7 @@ export async function validateCrossReferences(
     const diagnostics: Diagnostic[] = [];
     const filePath = uriToPath(documentUri);
     const currentDir = path.dirname(filePath);
-    const workspaceFolders = keySpaceService?.getWorkspaceFolders() ?? [];
+    const workspaceFolders = effectiveWorkspaceFolders(filePath, keySpaceService?.getWorkspaceFolders() ?? []);
 
     // Strip comments/CDATA to avoid matching inside them
     const cleanText = stripCommentsAndCodeContent(text);

--- a/server/src/features/crossRefValidation.ts
+++ b/server/src/features/crossRefValidation.ts
@@ -12,7 +12,10 @@ import { KeySpaceService } from '../services/keySpaceService';
 import { parseReference } from '../utils/referenceParser';
 import { TOPIC_TYPE_NAMES, MAP_TYPE_NAMES } from '../data/ditaSpecialization';
 import { t } from '../utils/i18n';
-import { stripCommentsAndCodeContent, offsetToRange, escapeRegex, normalizeFsPath, uriToPath } from '../utils/textUtils';
+import {
+    stripCommentsAndCodeContent, offsetToRange, escapeRegex, normalizeFsPath, uriToPath,
+    isPathWithinWorkspace,
+} from '../utils/textUtils';
 
 const SOURCE = 'dita-lsp';
 
@@ -48,6 +51,7 @@ export async function validateCrossReferences(
     const diagnostics: Diagnostic[] = [];
     const filePath = uriToPath(documentUri);
     const currentDir = path.dirname(filePath);
+    const workspaceFolders = keySpaceService?.getWorkspaceFolders() ?? [];
 
     // Strip comments/CDATA to avoid matching inside them
     const cleanText = stripCommentsAndCodeContent(text);
@@ -110,6 +114,16 @@ export async function validateCrossReferences(
         // Check file existence
         if (parsed.filePath) {
             const targetPath = path.resolve(currentDir, parsed.filePath);
+            if (!isPathWithinWorkspace(targetPath, workspaceFolders)) {
+                diagnostics.push({
+                    severity: DiagnosticSeverity.Warning,
+                    range,
+                    message: t('xref.missingFile', parsed.filePath),
+                    code: XREF_CODES.MISSING_FILE,
+                    source: SOURCE,
+                });
+                continue;
+            }
             try {
                 await fsp.access(targetPath);
             } catch {

--- a/server/src/features/definition.ts
+++ b/server/src/features/definition.ts
@@ -16,7 +16,7 @@ import {
     findElementByIdOffset,
 } from '../utils/referenceParser';
 
-import { offsetToPosition, uriToPath, isPathWithinWorkspace } from '../utils/textUtils';
+import { offsetToPosition, uriToPath, isPathWithinWorkspace, effectiveWorkspaceFolders } from '../utils/textUtils';
 
 import { KeySpaceService } from '../services/keySpaceService';
 
@@ -36,7 +36,9 @@ export async function handleDefinition(
 
     const text = document.getText();
     const offset = document.offsetAt(params.position);
-    const workspaceFolders = keySpaceService?.getWorkspaceFolders() ?? [];
+    const workspaceFolders = effectiveWorkspaceFolders(
+        uriToPath(document.uri), keySpaceService?.getWorkspaceFolders() ?? []
+    );
 
     // Find the reference attribute at the cursor
     const ref = findReferenceAtOffset(text, offset);

--- a/server/src/features/definition.ts
+++ b/server/src/features/definition.ts
@@ -16,7 +16,7 @@ import {
     findElementByIdOffset,
 } from '../utils/referenceParser';
 
-import { offsetToPosition, uriToPath } from '../utils/textUtils';
+import { offsetToPosition, uriToPath, isPathWithinWorkspace } from '../utils/textUtils';
 
 import { KeySpaceService } from '../services/keySpaceService';
 
@@ -36,6 +36,7 @@ export async function handleDefinition(
 
     const text = document.getText();
     const offset = document.offsetAt(params.position);
+    const workspaceFolders = keySpaceService?.getWorkspaceFolders() ?? [];
 
     // Find the reference attribute at the cursor
     const ref = findReferenceAtOffset(text, offset);
@@ -55,6 +56,7 @@ export async function handleDefinition(
             return resolveElementInFile(
                 keyDef.targetFile,
                 URI.file(keyDef.targetFile).toString(),
+                workspaceFolders,
                 keyDef.elementId
             );
         }
@@ -79,6 +81,7 @@ export async function handleDefinition(
                 return resolveElementInFile(
                     keyDef.targetFile,
                     URI.file(keyDef.targetFile).toString(),
+                    workspaceFolders,
                     elementId || keyDef.elementId
                 );
             }
@@ -103,7 +106,9 @@ export async function handleDefinition(
     // Cross-file reference
     const currentDir = path.dirname(uriToPath(document.uri));
     const targetPath = path.resolve(currentDir, parsed.filePath);
-    return resolveElementInFile(targetPath, URI.file(targetPath).toString(), targetId || undefined);
+    return resolveElementInFile(
+        targetPath, URI.file(targetPath).toString(), workspaceFolders, targetId || undefined
+    );
 }
 
 /**
@@ -131,9 +136,11 @@ function resolveInDocument(
 function resolveElementInFile(
     filePath: string,
     fileUri: string,
+    workspaceFolders: readonly string[],
     elementId?: string
 ): Location | null {
     try {
+        if (!isPathWithinWorkspace(filePath, workspaceFolders)) return null;
         if (!fs.existsSync(filePath)) return null;
 
         if (!elementId) {

--- a/server/src/features/documentLinks.ts
+++ b/server/src/features/documentLinks.ts
@@ -9,7 +9,7 @@ import {
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { URI } from 'vscode-uri';
 import { KeySpaceService } from '../services/keySpaceService';
-import { uriToPath } from '../utils/textUtils';
+import { uriToPath, isPathWithinWorkspace } from '../utils/textUtils';
 
 // --- Types ---
 
@@ -27,7 +27,8 @@ interface LinkData {
  */
 export async function handleDocumentLinks(
     params: DocumentLinkParams,
-    documents: TextDocuments<TextDocument>
+    documents: TextDocuments<TextDocument>,
+    keySpaceService?: KeySpaceService
 ): Promise<DocumentLink[]> {
     const document = documents.get(params.textDocument.uri);
     if (!document) return [];
@@ -36,6 +37,7 @@ export async function handleDocumentLinks(
     const documentUri = params.textDocument.uri;
     const documentDir = path.dirname(uriToPath(documentUri));
     const contextFilePath = uriToPath(documentUri);
+    const workspaceFolders = keySpaceService?.getWorkspaceFolders() ?? [];
     const links: DocumentLink[] = [];
 
     // Regex patterns (created per-call to avoid shared stateful /g flag)
@@ -50,10 +52,10 @@ export async function handleDocumentLinks(
     const commentRanges = getCommentRanges(text);
 
     // Process file-based references (resolve target immediately)
-    processFileRefs(text, document, documentDir, links, commentRanges, HREF_REGEX);
-    processFileRefs(text, document, documentDir, links, commentRanges, CONREF_REGEX);
-    processFileRefs(text, document, documentDir, links, commentRanges, XREF_HREF_REGEX);
-    processFileRefs(text, document, documentDir, links, commentRanges, LINK_HREF_REGEX);
+    processFileRefs(text, document, documentDir, links, commentRanges, HREF_REGEX, workspaceFolders);
+    processFileRefs(text, document, documentDir, links, commentRanges, CONREF_REGEX, workspaceFolders);
+    processFileRefs(text, document, documentDir, links, commentRanges, XREF_HREF_REGEX, workspaceFolders);
+    processFileRefs(text, document, documentDir, links, commentRanges, LINK_HREF_REGEX, workspaceFolders);
 
     // Process key-based references (deferred resolution via resolveDocumentLink)
     // KEYREF_REGEX covers all elements including xref (no separate xref keyref pattern needed)
@@ -166,7 +168,8 @@ function processFileRefs(
     documentDir: string,
     links: DocumentLink[],
     commentRanges: [number, number][],
-    pattern: RegExp
+    pattern: RegExp,
+    workspaceFolders: readonly string[]
 ): void {
     pattern.lastIndex = 0;
     let match;
@@ -197,6 +200,7 @@ function processFileRefs(
         }
 
         const targetPath = path.resolve(documentDir, filePart);
+        if (!isPathWithinWorkspace(targetPath, workspaceFolders)) continue;
         const targetUri = URI.file(targetPath).toString();
 
         links.push({

--- a/server/src/features/documentLinks.ts
+++ b/server/src/features/documentLinks.ts
@@ -9,7 +9,7 @@ import {
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { URI } from 'vscode-uri';
 import { KeySpaceService } from '../services/keySpaceService';
-import { uriToPath, isPathWithinWorkspace } from '../utils/textUtils';
+import { uriToPath, isPathWithinWorkspace, effectiveWorkspaceFolders } from '../utils/textUtils';
 
 // --- Types ---
 
@@ -37,7 +37,7 @@ export async function handleDocumentLinks(
     const documentUri = params.textDocument.uri;
     const documentDir = path.dirname(uriToPath(documentUri));
     const contextFilePath = uriToPath(documentUri);
-    const workspaceFolders = keySpaceService?.getWorkspaceFolders() ?? [];
+    const workspaceFolders = effectiveWorkspaceFolders(contextFilePath, keySpaceService?.getWorkspaceFolders() ?? []);
     const links: DocumentLink[] = [];
 
     // Regex patterns (created per-call to avoid shared stateful /g flag)

--- a/server/src/features/folding.ts
+++ b/server/src/features/folding.ts
@@ -69,7 +69,12 @@ export function computeFoldingRanges(text: string): FoldingRange[] {
                 if (tagStack[j].name === closeName) {
                     const openLine = tagStack[j].line;
                     const closeLine = lineAtOffset(lineOffsets, match.index);
-                    tagStack.splice(j, 1);
+                    // Resync: drop this entry and every intervening entry
+                    // above it (never-closed ancestors from a mismatched or
+                    // missing closing tag) instead of removing only the
+                    // matched one, which would leave them stuck in the stack
+                    // and corrupt fold ranges for the rest of the document.
+                    tagStack.length = j;
                     if (closeLine > openLine) {
                         ranges.push({
                             startLine: openLine,

--- a/server/src/features/folding.ts
+++ b/server/src/features/folding.ts
@@ -6,6 +6,7 @@ import {
 } from 'vscode-languageserver/node';
 
 import { TextDocument } from 'vscode-languageserver-textdocument';
+import { resyncStackToMatch } from '../utils/tagStack';
 
 // --- Types ---
 
@@ -65,26 +66,21 @@ export function computeFoldingRanges(text: string): FoldingRange[] {
         } else if (match[3]) {
             // Closing tag — match[4] is the tag name
             const closeName = match[4];
-            for (let j = tagStack.length - 1; j >= 0; j--) {
-                if (tagStack[j].name === closeName) {
-                    const openLine = tagStack[j].line;
-                    const closeLine = lineAtOffset(lineOffsets, match.index);
-                    // Resync: drop this entry and every intervening entry
-                    // above it (never-closed ancestors from a mismatched or
-                    // missing closing tag) instead of removing only the
-                    // matched one, which would leave them stuck in the stack
-                    // and corrupt fold ranges for the rest of the document.
-                    tagStack.length = j;
-                    if (closeLine > openLine) {
-                        ranges.push({
-                            startLine: openLine,
-                            endLine: closeLine,
-                            kind: FoldingRangeKind.Region,
-                        });
-                    }
-                    break;
+            const closeLine = lineAtOffset(lineOffsets, match.index);
+            // Resync: drop this entry and every intervening entry above it
+            // (never-closed ancestors from a mismatched or missing closing
+            // tag) instead of removing only the matched one, which would
+            // leave them stuck in the stack and corrupt fold ranges for the
+            // rest of the document.
+            resyncStackToMatch(tagStack, closeName, e => e.name, (entry, _index, isMatch) => {
+                if (isMatch && closeLine > entry.line) {
+                    ranges.push({
+                        startLine: entry.line,
+                        endLine: closeLine,
+                        kind: FoldingRangeKind.Region,
+                    });
                 }
-            }
+            });
         } else if (match[5]) {
             // Self-closing — no folding range
         } else if (match[7]) {

--- a/server/src/features/fragmentValidator.ts
+++ b/server/src/features/fragmentValidator.ts
@@ -9,7 +9,7 @@
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { Diagnostic, DiagnosticSeverity } from 'vscode-languageserver/node';
 import { ValidationPipeline } from '../services/validationPipeline';
-import { getGlobalSettings } from '../settings';
+import { getDocumentSettings } from '../settings';
 
 // ── Request / Response types (mirrored on the client) ─────────────────────
 
@@ -47,7 +47,7 @@ function wrapFragment(fragment: string, fragmentType: ValidateFragmentParams['fr
             return `<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">\n<topic id="_frag">\n<title>Fragment</title>\n<body>\n${trimmed}\n</body>\n</topic>`;
         case 'map':
             return trimmed.startsWith('<map') ? trimmed :
-                `<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">\n${trimmed}`;
+                `<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">\n<map>\n${trimmed}\n</map>`;
         default:
             return trimmed;
     }
@@ -69,7 +69,11 @@ export async function handleValidateFragment(
     const syntheticUri = `ditacraft-fragment:///fragment.${langId}`;
     const doc = TextDocument.create(syntheticUri, langId, 0, wrapped);
 
-    const settings = getGlobalSettings();
+    // Use the real parent document's settings (respects per-scope config from the
+    // client) instead of the module-level global, which only gets populated when
+    // the client lacks configuration-pull capability and otherwise stays at
+    // hardcoded defaults for the whole session.
+    const settings = await getDocumentSettings(params.contextUri);
     // For fragment validation, skip heavy workspace-level phases
     const lightSettings = {
         ...settings,

--- a/server/src/features/hover.ts
+++ b/server/src/features/hover.ts
@@ -14,7 +14,7 @@ import { ELEMENT_DOCS, DITA_ELEMENTS } from '../data/ditaSchema';
 import { findReferenceAtOffset, parseReference } from '../utils/referenceParser';
 import { KeySpaceService } from '../services/keySpaceService';
 import { TAG_ATTRS } from '../utils/patterns';
-import { uriToPath } from '../utils/textUtils';
+import { uriToPath, isPathWithinWorkspace } from '../utils/textUtils';
 
 /**
  * Handle hover requests.
@@ -43,7 +43,8 @@ export async function handleHover(
         }
 
         if (refAtOffset.type === 'href' || refAtOffset.type === 'conref') {
-            const hover = await getHrefHover(refAtOffset, params.textDocument.uri);
+            const workspaceFolders = keySpaceService?.getWorkspaceFolders() ?? [];
+            const hover = await getHrefHover(refAtOffset, params.textDocument.uri, workspaceFolders);
             if (hover) return hover;
         }
     }
@@ -155,7 +156,8 @@ async function getKeyrefHover(
  */
 async function getHrefHover(
     ref: { type: string; value: string },
-    documentUri: string
+    documentUri: string,
+    workspaceFolders: readonly string[]
 ): Promise<Hover | null> {
     if (!ref.value) return null;
 
@@ -179,13 +181,19 @@ async function getHrefHover(
     const contents: string[] = [];
     contents.push(`**${ref.type}:** \`${ref.value}\``);
 
+    const outsideWorkspace = !!parsed.filePath && !isPathWithinWorkspace(resolvedPath, workspaceFolders);
+
     try {
         if (parsed.filePath) {
             contents.push(`**Resolved:** ${resolvedPath}`);
-            try {
-                await fs.access(resolvedPath);
-            } catch {
-                contents.push('**Warning:** Target file not found');
+            if (outsideWorkspace) {
+                contents.push('**Warning:** Target path resolves outside the workspace');
+            } else {
+                try {
+                    await fs.access(resolvedPath);
+                } catch {
+                    contents.push('**Warning:** Target file not found');
+                }
             }
         } else {
             contents.push('**Same-file reference**');
@@ -196,7 +204,7 @@ async function getHrefHover(
         }
 
         // Conref content preview — show the referenced element's content
-        if (ref.type === 'conref' && parsed.fragment) {
+        if (ref.type === 'conref' && parsed.fragment && !outsideWorkspace) {
             const preview = await getConrefPreview(resolvedPath, parsed.fragment);
             if (preview) {
                 contents.push(`---\n\n**Preview:**\n\n\`\`\`xml\n${preview}\n\`\`\``);

--- a/server/src/features/hover.ts
+++ b/server/src/features/hover.ts
@@ -14,7 +14,7 @@ import { ELEMENT_DOCS, DITA_ELEMENTS } from '../data/ditaSchema';
 import { findReferenceAtOffset, parseReference } from '../utils/referenceParser';
 import { KeySpaceService } from '../services/keySpaceService';
 import { TAG_ATTRS } from '../utils/patterns';
-import { uriToPath, isPathWithinWorkspace } from '../utils/textUtils';
+import { uriToPath, isPathWithinWorkspace, effectiveWorkspaceFolders } from '../utils/textUtils';
 
 /**
  * Handle hover requests.
@@ -43,7 +43,9 @@ export async function handleHover(
         }
 
         if (refAtOffset.type === 'href' || refAtOffset.type === 'conref') {
-            const workspaceFolders = keySpaceService?.getWorkspaceFolders() ?? [];
+            const workspaceFolders = effectiveWorkspaceFolders(
+                uriToPath(params.textDocument.uri), keySpaceService?.getWorkspaceFolders() ?? []
+            );
             const hover = await getHrefHover(refAtOffset, params.textDocument.uri, workspaceFolders);
             if (hover) return hover;
         }

--- a/server/src/features/references.ts
+++ b/server/src/features/references.ts
@@ -17,7 +17,7 @@ import {
 } from '../utils/referenceParser';
 
 import { findCrossFileReferences } from '../utils/workspaceScanner';
-import { uriToPath } from '../utils/textUtils';
+import { uriToPath, normalizeFsPath } from '../utils/textUtils';
 import { KeySpaceService } from '../services/keySpaceService';
 
 /**
@@ -61,7 +61,7 @@ export async function handleReferences(
     // file may reference a *different* file's element that merely shares
     // the same id text, and must not be reported as a match.
     const targetFilePath = uriToPath(document.uri);
-    const normalizedTargetPath = path.normalize(targetFilePath);
+    const normalizedTargetPath = normalizeFsPath(targetFilePath);
     const refs = findReferencesToId(text, idResult.id);
     for (const ref of await filterMatchingRefs(
         refs, targetFilePath, normalizedTargetPath, keySpaceService
@@ -105,9 +105,9 @@ async function filterMatchingRefs(
         if (ref.type === 'href' || ref.type === 'conref') {
             const parsed = parseReference(ref.value);
             if (parsed.filePath) {
-                const resolvedPath = path.normalize(path.resolve(contextDir, parsed.filePath));
+                const resolvedPath = normalizeFsPath(path.resolve(contextDir, parsed.filePath));
                 if (resolvedPath !== normalizedTargetPath) continue;
-            } else if (path.normalize(contextFilePath) !== normalizedTargetPath) {
+            } else if (normalizeFsPath(contextFilePath) !== normalizedTargetPath) {
                 continue;
             }
         } else if (ref.type === 'conkeyref') {
@@ -115,7 +115,7 @@ async function filterMatchingRefs(
             const slashIdx = ref.value.indexOf('/');
             const keyName = slashIdx >= 0 ? ref.value.slice(0, slashIdx) : ref.value;
             const keyDef = await keySpaceService.resolveKey(keyName, contextFilePath);
-            const resolvedTarget = keyDef?.targetFile ? path.normalize(keyDef.targetFile) : null;
+            const resolvedTarget = keyDef?.targetFile ? normalizeFsPath(keyDef.targetFile) : null;
             if (resolvedTarget !== normalizedTargetPath) continue;
         }
         matching.push(ref);

--- a/server/src/features/references.ts
+++ b/server/src/features/references.ts
@@ -1,4 +1,3 @@
-import * as path from 'path';
 import {
     Location,
     ReferenceParams,
@@ -12,11 +11,10 @@ import {
     findIdAtOffset,
     findReferencesToId,
     findElementByIdOffset,
-    parseReference,
     ReferenceOccurrence,
 } from '../utils/referenceParser';
 
-import { findCrossFileReferences } from '../utils/workspaceScanner';
+import { findCrossFileReferences, referenceMatchesTarget } from '../utils/workspaceScanner';
 import { uriToPath, normalizeFsPath } from '../utils/textUtils';
 import { KeySpaceService } from '../services/keySpaceService';
 
@@ -101,33 +99,12 @@ async function filterMatchingRefs(
     keySpaceService: KeySpaceService | undefined,
     log?: (msg: string) => void
 ): Promise<ReferenceOccurrence[]> {
-    const contextDir = path.dirname(contextFilePath);
     const matching: ReferenceOccurrence[] = [];
 
     for (const ref of refs) {
-        if (ref.type === 'href' || ref.type === 'conref') {
-            const parsed = parseReference(ref.value);
-            if (parsed.filePath) {
-                const resolvedPath = normalizeFsPath(path.resolve(contextDir, parsed.filePath));
-                if (resolvedPath !== normalizedTargetPath) continue;
-            } else if (normalizeFsPath(contextFilePath) !== normalizedTargetPath) {
-                continue;
-            }
-        } else if (ref.type === 'conkeyref') {
-            if (!keySpaceService) {
-                log?.(
-                    `Find References: skipping unverifiable conkeyref "${ref.value}" in ${contextFilePath} ` +
-                    '(no KeySpaceService available to resolve the key target)'
-                );
-                continue;
-            }
-            const slashIdx = ref.value.indexOf('/');
-            const keyName = slashIdx >= 0 ? ref.value.slice(0, slashIdx) : ref.value;
-            const keyDef = await keySpaceService.resolveKey(keyName, contextFilePath);
-            const resolvedTarget = keyDef?.targetFile ? normalizeFsPath(keyDef.targetFile) : null;
-            if (resolvedTarget !== normalizedTargetPath) continue;
+        if (await referenceMatchesTarget(ref, contextFilePath, normalizedTargetPath, keySpaceService, log)) {
+            matching.push(ref);
         }
-        matching.push(ref);
     }
 
     return matching;

--- a/server/src/features/references.ts
+++ b/server/src/features/references.ts
@@ -29,7 +29,8 @@ export async function handleReferences(
     params: ReferenceParams,
     documents: TextDocuments<TextDocument>,
     workspaceFolders?: readonly string[],
-    keySpaceService?: KeySpaceService
+    keySpaceService?: KeySpaceService,
+    log?: (msg: string) => void
 ): Promise<Location[]> {
     const document = documents.get(params.textDocument.uri);
     if (!document) {
@@ -64,7 +65,7 @@ export async function handleReferences(
     const normalizedTargetPath = normalizeFsPath(targetFilePath);
     const refs = findReferencesToId(text, idResult.id);
     for (const ref of await filterMatchingRefs(
-        refs, targetFilePath, normalizedTargetPath, keySpaceService
+        refs, targetFilePath, normalizedTargetPath, keySpaceService, log
     )) {
         const startPos = document.positionAt(ref.valueStart);
         const endPos = document.positionAt(ref.valueEnd);
@@ -79,7 +80,8 @@ export async function handleReferences(
             workspaceFolders,
             document.uri,
             documents,
-            keySpaceService
+            keySpaceService,
+            log
         );
         results.push(...crossFileRefs);
     }
@@ -96,7 +98,8 @@ async function filterMatchingRefs(
     refs: ReferenceOccurrence[],
     contextFilePath: string,
     normalizedTargetPath: string,
-    keySpaceService: KeySpaceService | undefined
+    keySpaceService: KeySpaceService | undefined,
+    log?: (msg: string) => void
 ): Promise<ReferenceOccurrence[]> {
     const contextDir = path.dirname(contextFilePath);
     const matching: ReferenceOccurrence[] = [];
@@ -111,7 +114,13 @@ async function filterMatchingRefs(
                 continue;
             }
         } else if (ref.type === 'conkeyref') {
-            if (!keySpaceService) continue;
+            if (!keySpaceService) {
+                log?.(
+                    `Find References: skipping unverifiable conkeyref "${ref.value}" in ${contextFilePath} ` +
+                    '(no KeySpaceService available to resolve the key target)'
+                );
+                continue;
+            }
             const slashIdx = ref.value.indexOf('/');
             const keyName = slashIdx >= 0 ? ref.value.slice(0, slashIdx) : ref.value;
             const keyDef = await keySpaceService.resolveKey(keyName, contextFilePath);

--- a/server/src/features/references.ts
+++ b/server/src/features/references.ts
@@ -1,3 +1,4 @@
+import * as path from 'path';
 import {
     Location,
     ReferenceParams,
@@ -11,21 +12,25 @@ import {
     findIdAtOffset,
     findReferencesToId,
     findElementByIdOffset,
+    parseReference,
+    ReferenceOccurrence,
 } from '../utils/referenceParser';
 
 import { findCrossFileReferences } from '../utils/workspaceScanner';
 import { uriToPath } from '../utils/textUtils';
+import { KeySpaceService } from '../services/keySpaceService';
 
 /**
  * Handle Find References requests.
  * Searches the current document and all workspace DITA files for references
  * to the ID at the cursor position.
  */
-export function handleReferences(
+export async function handleReferences(
     params: ReferenceParams,
     documents: TextDocuments<TextDocument>,
-    workspaceFolders?: readonly string[]
-): Location[] {
+    workspaceFolders?: readonly string[],
+    keySpaceService?: KeySpaceService
+): Promise<Location[]> {
     const document = documents.get(params.textDocument.uri);
     if (!document) {
         return [];
@@ -51,9 +56,16 @@ export function handleReferences(
         }
     }
 
-    // Find all references to this ID in the current document
+    // Find all references to this ID in the current document. Filtered the
+    // same way as cross-file refs below — a href/conref/conkeyref in this
+    // file may reference a *different* file's element that merely shares
+    // the same id text, and must not be reported as a match.
+    const targetFilePath = uriToPath(document.uri);
+    const normalizedTargetPath = path.normalize(targetFilePath);
     const refs = findReferencesToId(text, idResult.id);
-    for (const ref of refs) {
+    for (const ref of await filterMatchingRefs(
+        refs, targetFilePath, normalizedTargetPath, keySpaceService
+    )) {
         const startPos = document.positionAt(ref.valueStart);
         const endPos = document.positionAt(ref.valueEnd);
         results.push(Location.create(document.uri, { start: startPos, end: endPos }));
@@ -61,16 +73,53 @@ export function handleReferences(
 
     // Find references across all workspace files
     if (workspaceFolders && workspaceFolders.length > 0) {
-        const targetFilePath = uriToPath(document.uri);
-        const crossFileRefs = findCrossFileReferences(
+        const crossFileRefs = await findCrossFileReferences(
             idResult.id,
             targetFilePath,
             workspaceFolders,
             document.uri,
-            documents
+            documents,
+            keySpaceService
         );
         results.push(...crossFileRefs);
     }
 
     return results;
+}
+
+/**
+ * Filter reference occurrences found in `contextFilePath` down to only those
+ * that actually point at `normalizedTargetPath`. Mirrors the filtering used
+ * for cross-file references in workspaceScanner.ts's findCrossFileReferences.
+ */
+async function filterMatchingRefs(
+    refs: ReferenceOccurrence[],
+    contextFilePath: string,
+    normalizedTargetPath: string,
+    keySpaceService: KeySpaceService | undefined
+): Promise<ReferenceOccurrence[]> {
+    const contextDir = path.dirname(contextFilePath);
+    const matching: ReferenceOccurrence[] = [];
+
+    for (const ref of refs) {
+        if (ref.type === 'href' || ref.type === 'conref') {
+            const parsed = parseReference(ref.value);
+            if (parsed.filePath) {
+                const resolvedPath = path.normalize(path.resolve(contextDir, parsed.filePath));
+                if (resolvedPath !== normalizedTargetPath) continue;
+            } else if (path.normalize(contextFilePath) !== normalizedTargetPath) {
+                continue;
+            }
+        } else if (ref.type === 'conkeyref') {
+            if (!keySpaceService) continue;
+            const slashIdx = ref.value.indexOf('/');
+            const keyName = slashIdx >= 0 ? ref.value.slice(0, slashIdx) : ref.value;
+            const keyDef = await keySpaceService.resolveKey(keyName, contextFilePath);
+            const resolvedTarget = keyDef?.targetFile ? path.normalize(keyDef.targetFile) : null;
+            if (resolvedTarget !== normalizedTargetPath) continue;
+        }
+        matching.push(ref);
+    }
+
+    return matching;
 }

--- a/server/src/features/rename.ts
+++ b/server/src/features/rename.ts
@@ -91,13 +91,16 @@ export async function handleRename(
     currentEdits.push(...selfEdits);
     changes[document.uri] = currentEdits;
 
-    // 3. Cross-file: update references in other workspace files
+    // 3. Cross-file: update references in other workspace files. Files are
+    // processed concurrently (KeySpaceService dedupes concurrent builds of
+    // the same key space via pendingBuilds) since each file's conkeyref
+    // matches otherwise resolve one at a time.
     if (workspaceFolders && workspaceFolders.length > 0) {
         const ditaFiles = collectDitaFiles(workspaceFolders);
 
-        for (const filePath of ditaFiles) {
+        const perFileEdits = await Promise.all(ditaFiles.map(async (filePath) => {
             const fileUri = URI.file(filePath).toString();
-            if (fileUri === document.uri) continue;
+            if (fileUri === document.uri) return null;
 
             // Prefer in-memory content for open documents (may have unsaved changes)
             const openDoc = documents.get(fileUri);
@@ -108,19 +111,23 @@ export async function handleRename(
                 try {
                     content = fs.readFileSync(filePath, 'utf-8');
                 } catch {
-                    continue;
+                    return null;
                 }
             }
 
             const fileRefs = findReferencesToId(content, oldId);
-            if (fileRefs.length === 0) continue;
+            if (fileRefs.length === 0) return null;
 
             const fileEdits = await collectMatchingEdits(
                 fileRefs, content, filePath, normalizedTargetPath, oldId, newId, keySpaceService, log
             );
 
-            if (fileEdits.length > 0) {
-                changes[fileUri] = fileEdits;
+            return fileEdits.length > 0 ? { fileUri, fileEdits } : null;
+        }));
+
+        for (const result of perFileEdits) {
+            if (result) {
+                changes[result.fileUri] = result.fileEdits;
             }
         }
     }
@@ -149,12 +156,13 @@ async function collectMatchingEdits(
     keySpaceService: KeySpaceService | undefined,
     log?: (msg: string) => void
 ): Promise<TextEdit[]> {
-    const edits: TextEdit[] = [];
+    const matchFlags = await Promise.all(
+        refs.map(ref => referenceMatchesTarget(ref, contextFilePath, normalizedTargetPath, keySpaceService, log))
+    );
 
-    for (const ref of refs) {
-        if (!(await referenceMatchesTarget(ref, contextFilePath, normalizedTargetPath, keySpaceService, log))) {
-            continue;
-        }
+    const edits: TextEdit[] = [];
+    refs.forEach((ref, i) => {
+        if (!matchFlags[i]) return;
 
         const newValue = replaceIdInReference(ref.type, ref.value, oldId, newId);
         const startPos = offsetToPosition(content, ref.valueStart);
@@ -163,7 +171,7 @@ async function collectMatchingEdits(
             range: Range.create(startPos, endPos),
             newText: newValue,
         });
-    }
+    });
 
     return edits;
 }

--- a/server/src/features/rename.ts
+++ b/server/src/features/rename.ts
@@ -1,5 +1,4 @@
 import * as fs from 'fs';
-import * as path from 'path';
 import {
     PrepareRenameParams,
     RenameParams,
@@ -15,11 +14,10 @@ import { URI } from 'vscode-uri';
 import {
     findIdAtOffset,
     findReferencesToId,
-    parseReference,
     ReferenceOccurrence,
 } from '../utils/referenceParser';
 
-import { collectDitaFiles } from '../utils/workspaceScanner';
+import { collectDitaFiles, referenceMatchesTarget } from '../utils/workspaceScanner';
 import { offsetToPosition, uriToPath, normalizeFsPath } from '../utils/textUtils';
 import { KeySpaceService } from '../services/keySpaceService';
 
@@ -151,32 +149,11 @@ async function collectMatchingEdits(
     keySpaceService: KeySpaceService | undefined,
     log?: (msg: string) => void
 ): Promise<TextEdit[]> {
-    const contextDir = path.dirname(contextFilePath);
     const edits: TextEdit[] = [];
 
     for (const ref of refs) {
-        if (ref.type === 'href' || ref.type === 'conref') {
-            const parsed = parseReference(ref.value);
-            if (parsed.filePath) {
-                const resolvedPath = normalizeFsPath(path.resolve(contextDir, parsed.filePath));
-                if (resolvedPath !== normalizedTargetPath) continue;
-            } else {
-                // Fragment-only ref: only relevant when this file is the target file
-                if (normalizeFsPath(contextFilePath) !== normalizedTargetPath) continue;
-            }
-        } else if (ref.type === 'conkeyref') {
-            if (!keySpaceService) {
-                log?.(
-                    `Rename: skipping unverifiable conkeyref "${ref.value}" in ${contextFilePath} ` +
-                    '(no KeySpaceService available to resolve the key target)'
-                );
-                continue;
-            }
-            const slashIdx = ref.value.indexOf('/');
-            const keyName = slashIdx >= 0 ? ref.value.slice(0, slashIdx) : ref.value;
-            const keyDef = await keySpaceService.resolveKey(keyName, contextFilePath);
-            const resolvedTarget = keyDef?.targetFile ? normalizeFsPath(keyDef.targetFile) : null;
-            if (resolvedTarget !== normalizedTargetPath) continue;
+        if (!(await referenceMatchesTarget(ref, contextFilePath, normalizedTargetPath, keySpaceService, log))) {
+            continue;
         }
 
         const newValue = replaceIdInReference(ref.type, ref.value, oldId, newId);

--- a/server/src/features/rename.ts
+++ b/server/src/features/rename.ts
@@ -54,7 +54,8 @@ export async function handleRename(
     params: RenameParams,
     documents: TextDocuments<TextDocument>,
     workspaceFolders?: readonly string[],
-    keySpaceService?: KeySpaceService
+    keySpaceService?: KeySpaceService,
+    log?: (msg: string) => void
 ): Promise<WorkspaceEdit | null> {
     const document = documents.get(params.textDocument.uri);
     if (!document) return null;
@@ -87,7 +88,7 @@ export async function handleRename(
     const normalizedTargetPath = normalizeFsPath(targetFilePath);
     const refs = findReferencesToId(text, oldId);
     const selfEdits = await collectMatchingEdits(
-        refs, text, targetFilePath, normalizedTargetPath, oldId, newId, keySpaceService
+        refs, text, targetFilePath, normalizedTargetPath, oldId, newId, keySpaceService, log
     );
     currentEdits.push(...selfEdits);
     changes[document.uri] = currentEdits;
@@ -117,7 +118,7 @@ export async function handleRename(
             if (fileRefs.length === 0) continue;
 
             const fileEdits = await collectMatchingEdits(
-                fileRefs, content, filePath, normalizedTargetPath, oldId, newId, keySpaceService
+                fileRefs, content, filePath, normalizedTargetPath, oldId, newId, keySpaceService, log
             );
 
             if (fileEdits.length > 0) {
@@ -147,7 +148,8 @@ async function collectMatchingEdits(
     normalizedTargetPath: string,
     oldId: string,
     newId: string,
-    keySpaceService: KeySpaceService | undefined
+    keySpaceService: KeySpaceService | undefined,
+    log?: (msg: string) => void
 ): Promise<TextEdit[]> {
     const contextDir = path.dirname(contextFilePath);
     const edits: TextEdit[] = [];
@@ -163,7 +165,13 @@ async function collectMatchingEdits(
                 if (normalizeFsPath(contextFilePath) !== normalizedTargetPath) continue;
             }
         } else if (ref.type === 'conkeyref') {
-            if (!keySpaceService) continue;
+            if (!keySpaceService) {
+                log?.(
+                    `Rename: skipping unverifiable conkeyref "${ref.value}" in ${contextFilePath} ` +
+                    '(no KeySpaceService available to resolve the key target)'
+                );
+                continue;
+            }
             const slashIdx = ref.value.indexOf('/');
             const keyName = slashIdx >= 0 ? ref.value.slice(0, slashIdx) : ref.value;
             const keyDef = await keySpaceService.resolveKey(keyName, contextFilePath);

--- a/server/src/features/rename.ts
+++ b/server/src/features/rename.ts
@@ -16,10 +16,12 @@ import {
     findIdAtOffset,
     findReferencesToId,
     parseReference,
+    ReferenceOccurrence,
 } from '../utils/referenceParser';
 
 import { collectDitaFiles } from '../utils/workspaceScanner';
 import { offsetToPosition, uriToPath } from '../utils/textUtils';
+import { KeySpaceService } from '../services/keySpaceService';
 
 /**
  * Handle Prepare Rename request.
@@ -48,11 +50,12 @@ export function handlePrepareRename(
  * Handle Rename request.
  * Renames an id attribute value and updates all references across the workspace.
  */
-export function handleRename(
+export async function handleRename(
     params: RenameParams,
     documents: TextDocuments<TextDocument>,
-    workspaceFolders?: readonly string[]
-): WorkspaceEdit | null {
+    workspaceFolders?: readonly string[],
+    keySpaceService?: KeySpaceService
+): Promise<WorkspaceEdit | null> {
     const document = documents.get(params.textDocument.uri);
     if (!document) return null;
 
@@ -76,24 +79,21 @@ export function handleRename(
         newText: newId,
     });
 
-    // 2. Update all references to this ID in the current document
+    // 2. Update all references to this ID in the current document.
+    // Filtered the same way as cross-file refs below — a href/conref/conkeyref
+    // in this file may reference a *different* file's element that merely
+    // shares the same id text, and must not be rewritten.
+    const targetFilePath = uriToPath(document.uri);
+    const normalizedTargetPath = path.normalize(targetFilePath);
     const refs = findReferencesToId(text, oldId);
-    for (const ref of refs) {
-        const newValue = replaceIdInReference(ref.type, ref.value, oldId, newId);
-        currentEdits.push({
-            range: Range.create(
-                document.positionAt(ref.valueStart),
-                document.positionAt(ref.valueEnd)
-            ),
-            newText: newValue,
-        });
-    }
+    const selfEdits = await collectMatchingEdits(
+        refs, text, targetFilePath, normalizedTargetPath, oldId, newId, keySpaceService
+    );
+    currentEdits.push(...selfEdits);
     changes[document.uri] = currentEdits;
 
     // 3. Cross-file: update references in other workspace files
     if (workspaceFolders && workspaceFolders.length > 0) {
-        const targetFilePath = uriToPath(document.uri);
-        const normalizedTargetPath = path.normalize(targetFilePath);
         const ditaFiles = collectDitaFiles(workspaceFolders);
 
         for (const filePath of ditaFiles) {
@@ -116,33 +116,9 @@ export function handleRename(
             const fileRefs = findReferencesToId(content, oldId);
             if (fileRefs.length === 0) continue;
 
-            const fileDir = path.dirname(filePath);
-            const fileEdits: TextEdit[] = [];
-
-            for (const ref of fileRefs) {
-                // Filter: only include refs that point to the target file
-                if (ref.type === 'href' || ref.type === 'conref') {
-                    const parsed = parseReference(ref.value);
-                    if (parsed.filePath) {
-                        const resolvedPath = path.normalize(
-                            path.resolve(fileDir, parsed.filePath)
-                        );
-                        if (resolvedPath !== normalizedTargetPath) continue;
-                    } else {
-                        // Fragment-only ref: only relevant in the target file itself
-                        if (path.normalize(filePath) !== normalizedTargetPath) continue;
-                    }
-                }
-                // conkeyref: include all matches by element ID
-
-                const newValue = replaceIdInReference(ref.type, ref.value, oldId, newId);
-                const startPos = offsetToPosition(content, ref.valueStart);
-                const endPos = offsetToPosition(content, ref.valueEnd);
-                fileEdits.push({
-                    range: Range.create(startPos, endPos),
-                    newText: newValue,
-                });
-            }
+            const fileEdits = await collectMatchingEdits(
+                fileRefs, content, filePath, normalizedTargetPath, oldId, newId, keySpaceService
+            );
 
             if (fileEdits.length > 0) {
                 changes[fileUri] = fileEdits;
@@ -151,6 +127,60 @@ export function handleRename(
     }
 
     return { changes };
+}
+
+/**
+ * Filter reference occurrences found in `contextFilePath` down to only those
+ * that actually point at `normalizedTargetPath` (the file whose element is
+ * being renamed), then build the corresponding text edits.
+ *
+ * href/conref are filtered by resolving their file part relative to the
+ * containing file. conkeyref has no file part — the key must be resolved via
+ * the key space to know which file it targets. Without a KeySpaceService,
+ * a conkeyref match cannot be verified and is skipped rather than risking a
+ * rewrite of an unrelated file's reference that merely shares the id text.
+ */
+async function collectMatchingEdits(
+    refs: ReferenceOccurrence[],
+    content: string,
+    contextFilePath: string,
+    normalizedTargetPath: string,
+    oldId: string,
+    newId: string,
+    keySpaceService: KeySpaceService | undefined
+): Promise<TextEdit[]> {
+    const contextDir = path.dirname(contextFilePath);
+    const edits: TextEdit[] = [];
+
+    for (const ref of refs) {
+        if (ref.type === 'href' || ref.type === 'conref') {
+            const parsed = parseReference(ref.value);
+            if (parsed.filePath) {
+                const resolvedPath = path.normalize(path.resolve(contextDir, parsed.filePath));
+                if (resolvedPath !== normalizedTargetPath) continue;
+            } else {
+                // Fragment-only ref: only relevant when this file is the target file
+                if (path.normalize(contextFilePath) !== normalizedTargetPath) continue;
+            }
+        } else if (ref.type === 'conkeyref') {
+            if (!keySpaceService) continue;
+            const slashIdx = ref.value.indexOf('/');
+            const keyName = slashIdx >= 0 ? ref.value.slice(0, slashIdx) : ref.value;
+            const keyDef = await keySpaceService.resolveKey(keyName, contextFilePath);
+            const resolvedTarget = keyDef?.targetFile ? path.normalize(keyDef.targetFile) : null;
+            if (resolvedTarget !== normalizedTargetPath) continue;
+        }
+
+        const newValue = replaceIdInReference(ref.type, ref.value, oldId, newId);
+        const startPos = offsetToPosition(content, ref.valueStart);
+        const endPos = offsetToPosition(content, ref.valueEnd);
+        edits.push({
+            range: Range.create(startPos, endPos),
+            newText: newValue,
+        });
+    }
+
+    return edits;
 }
 
 /**

--- a/server/src/features/rename.ts
+++ b/server/src/features/rename.ts
@@ -20,7 +20,7 @@ import {
 } from '../utils/referenceParser';
 
 import { collectDitaFiles } from '../utils/workspaceScanner';
-import { offsetToPosition, uriToPath } from '../utils/textUtils';
+import { offsetToPosition, uriToPath, normalizeFsPath } from '../utils/textUtils';
 import { KeySpaceService } from '../services/keySpaceService';
 
 /**
@@ -84,7 +84,7 @@ export async function handleRename(
     // in this file may reference a *different* file's element that merely
     // shares the same id text, and must not be rewritten.
     const targetFilePath = uriToPath(document.uri);
-    const normalizedTargetPath = path.normalize(targetFilePath);
+    const normalizedTargetPath = normalizeFsPath(targetFilePath);
     const refs = findReferencesToId(text, oldId);
     const selfEdits = await collectMatchingEdits(
         refs, text, targetFilePath, normalizedTargetPath, oldId, newId, keySpaceService
@@ -156,18 +156,18 @@ async function collectMatchingEdits(
         if (ref.type === 'href' || ref.type === 'conref') {
             const parsed = parseReference(ref.value);
             if (parsed.filePath) {
-                const resolvedPath = path.normalize(path.resolve(contextDir, parsed.filePath));
+                const resolvedPath = normalizeFsPath(path.resolve(contextDir, parsed.filePath));
                 if (resolvedPath !== normalizedTargetPath) continue;
             } else {
                 // Fragment-only ref: only relevant when this file is the target file
-                if (path.normalize(contextFilePath) !== normalizedTargetPath) continue;
+                if (normalizeFsPath(contextFilePath) !== normalizedTargetPath) continue;
             }
         } else if (ref.type === 'conkeyref') {
             if (!keySpaceService) continue;
             const slashIdx = ref.value.indexOf('/');
             const keyName = slashIdx >= 0 ? ref.value.slice(0, slashIdx) : ref.value;
             const keyDef = await keySpaceService.resolveKey(keyName, contextFilePath);
-            const resolvedTarget = keyDef?.targetFile ? path.normalize(keyDef.targetFile) : null;
+            const resolvedTarget = keyDef?.targetFile ? normalizeFsPath(keyDef.targetFile) : null;
             if (resolvedTarget !== normalizedTargetPath) continue;
         }
 

--- a/server/src/features/symbols.ts
+++ b/server/src/features/symbols.ts
@@ -123,16 +123,24 @@ function buildSymbolTree(tags: ParsedTag[], document: TextDocument): DocumentSym
         const tag = tags[i];
 
         if (tag.isClosing) {
-            // Find matching opening tag on the stack
+            // Find matching opening tag on the stack, searching from the top down.
+            let matchIdx = -1;
             for (let j = stack.length - 1; j >= 0; j--) {
-                if (stack[j].name === tag.name) {
-                    // Update the range end to include the closing tag
-                    const entry = stack[j];
-                    entry.symbol.range.end = document.positionAt(tag.endOffset);
+                if (stack[j].name === tag.name) { matchIdx = j; break; }
+            }
+            if (matchIdx >= 0) {
+                // Finalize every entry from the top down through the match.
+                // Intervening entries (mismatched/missing closing tags) were
+                // never properly closed — leaving them on the stack would
+                // corrupt nesting for the rest of the document, so close them
+                // here too instead of only removing the matched entry.
+                const endPos = document.positionAt(tag.endOffset);
+                for (let k = stack.length - 1; k >= matchIdx; k--) {
+                    const entry = stack[k];
+                    entry.symbol.range.end = endPos;
                     entry.symbol.children = entry.children;
-                    stack.splice(j, 1);
-                    break;
                 }
+                stack.length = matchIdx;
             }
             continue;
         }
@@ -279,10 +287,12 @@ function extractWorkspaceSymbols(
 
     for (const tag of tags) {
         if (tag.isClosing) {
-            // Pop matching element from stack
+            // Pop matching element from stack, closing any intervening
+            // (mismatched/missing closing tag) entries above it too — leaving
+            // them stuck would misattribute containerName for the rest of the file.
             for (let j = openStack.length - 1; j >= 0; j--) {
                 if (openStack[j].name === tag.name) {
-                    openStack.splice(j, 1);
+                    openStack.length = j;
                     break;
                 }
             }

--- a/server/src/features/symbols.ts
+++ b/server/src/features/symbols.ts
@@ -14,6 +14,7 @@ import { URI } from 'vscode-uri';
 
 import { collectDitaFiles } from '../utils/workspaceScanner';
 import { offsetToPosition } from '../utils/textUtils';
+import { resyncStackToMatch } from '../utils/tagStack';
 
 /** Map DITA element names to LSP SymbolKind */
 const SYMBOL_KIND_MAP: Record<string, SymbolKind> = {
@@ -123,25 +124,16 @@ function buildSymbolTree(tags: ParsedTag[], document: TextDocument): DocumentSym
         const tag = tags[i];
 
         if (tag.isClosing) {
-            // Find matching opening tag on the stack, searching from the top down.
-            let matchIdx = -1;
-            for (let j = stack.length - 1; j >= 0; j--) {
-                if (stack[j].name === tag.name) { matchIdx = j; break; }
-            }
-            if (matchIdx >= 0) {
-                // Finalize every entry from the top down through the match.
-                // Intervening entries (mismatched/missing closing tags) were
-                // never properly closed — leaving them on the stack would
-                // corrupt nesting for the rest of the document, so close them
-                // here too instead of only removing the matched entry.
-                const endPos = document.positionAt(tag.endOffset);
-                for (let k = stack.length - 1; k >= matchIdx; k--) {
-                    const entry = stack[k];
-                    entry.symbol.range.end = endPos;
-                    entry.symbol.children = entry.children;
-                }
-                stack.length = matchIdx;
-            }
+            // Finalize every entry from the top down through the matching
+            // opening tag. Intervening entries (mismatched/missing closing
+            // tags) were never properly closed — leaving them on the stack
+            // would corrupt nesting for the rest of the document, so close
+            // them here too instead of only removing the matched entry.
+            const endPos = document.positionAt(tag.endOffset);
+            resyncStackToMatch(stack, tag.name, e => e.name, (entry) => {
+                entry.symbol.range.end = endPos;
+                entry.symbol.children = entry.children;
+            });
             continue;
         }
 
@@ -290,12 +282,7 @@ function extractWorkspaceSymbols(
             // Pop matching element from stack, closing any intervening
             // (mismatched/missing closing tag) entries above it too — leaving
             // them stuck would misattribute containerName for the rest of the file.
-            for (let j = openStack.length - 1; j >= 0; j--) {
-                if (openStack[j].name === tag.name) {
-                    openStack.length = j;
-                    break;
-                }
-            }
+            resyncStackToMatch(openStack, tag.name, e => e.name);
             continue;
         }
 

--- a/server/src/features/workspaceValidation.ts
+++ b/server/src/features/workspaceValidation.ts
@@ -25,9 +25,19 @@ function extractRootId(text: string): { tagName: string; id: string; index: numb
     const stripped = stripCommentsAndCDATA(text)
         .replace(/<\?[\s\S]*?\?>/g, (m) => ' '.repeat(m.length))
         .replace(/<!DOCTYPE[\s\S]*?>/g, (m) => ' '.repeat(m.length));
-    const rootMatch = stripped.match(/<(\w[\w.-]*)\s[^>]*\bid\s*=\s*["']([^"']+)["']/);
-    if (!rootMatch || rootMatch.index === undefined) return null;
-    return { tagName: rootMatch[1], id: rootMatch[2], index: rootMatch.index };
+
+    // Find the first real element — the document root — then look for an id
+    // attribute only within that specific tag's attributes. Searching the
+    // whole file for the first "id=" anywhere (the previous approach) could
+    // pick up a nested child's id when the root itself has none, misusing it
+    // as this file's "root ID" for cross-file duplicate detection.
+    const rootTagMatch = stripped.match(/<(\w[\w.-]*)([^>]*)>/);
+    if (!rootTagMatch || rootTagMatch.index === undefined) return null;
+
+    const idMatch = rootTagMatch[2].match(/\bid\s*=\s*["']([^"']+)["']/);
+    if (!idMatch) return null;
+
+    return { tagName: rootTagMatch[1], id: idMatch[1], index: rootTagMatch.index };
 }
 
 /** Max concurrent file reads to avoid exhausting file descriptors. */

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -427,7 +427,7 @@ connection.onRenameRequest((params: RenameParams) => {
 connection.onFoldingRanges((params: FoldingRangeParams) => handleFoldingRanges(params, documents));
 
 // Document Links handler
-connection.onDocumentLinks((params: DocumentLinkParams) => handleDocumentLinks(params, documents));
+connection.onDocumentLinks((params: DocumentLinkParams) => handleDocumentLinks(params, documents, keySpaceService));
 
 // Document Link Resolve handler
 connection.onDocumentLinkResolve((link: DocumentLink) => handleDocumentLinkResolve(link, keySpaceService));

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -402,7 +402,7 @@ connection.onDefinition((params: DefinitionParams) => handleDefinition(params, d
 // Find References handler (cross-file via workspace folders)
 connection.onReferences((params: ReferenceParams) => {
     const folders = keySpaceService?.getWorkspaceFolders();
-    return handleReferences(params, documents, folders);
+    return handleReferences(params, documents, folders, keySpaceService);
 });
 
 // Document formatting handler

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -420,7 +420,7 @@ connection.onPrepareRename((params: PrepareRenameParams) => handlePrepareRename(
 // Rename handler (cross-file via workspace folders)
 connection.onRenameRequest((params: RenameParams) => {
     const folders = keySpaceService?.getWorkspaceFolders();
-    return handleRename(params, documents, folders);
+    return handleRename(params, documents, folders, keySpaceService);
 });
 
 // Folding Ranges handler

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -407,7 +407,7 @@ connection.onDefinition((params: DefinitionParams) => handleDefinition(params, d
 // Find References handler (cross-file via workspace folders)
 connection.onReferences((params: ReferenceParams) => {
     const folders = keySpaceService?.getWorkspaceFolders();
-    return handleReferences(params, documents, folders, keySpaceService);
+    return handleReferences(params, documents, folders, keySpaceService, (msg) => connection.console.warn(msg));
 });
 
 // Document formatting handler
@@ -425,7 +425,7 @@ connection.onPrepareRename((params: PrepareRenameParams) => handlePrepareRename(
 // Rename handler (cross-file via workspace folders)
 connection.onRenameRequest((params: RenameParams) => {
     const folders = keySpaceService?.getWorkspaceFolders();
-    return handleRename(params, documents, folders, keySpaceService);
+    return handleRename(params, documents, folders, keySpaceService, (msg) => connection.console.warn(msg));
 });
 
 // Folding Ranges handler

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -322,9 +322,14 @@ connection.onDidChangeWatchedFiles(async (params: DidChangeWatchedFilesParams) =
     for (const change of classification.changes) {
         validationPipeline.invalidateForFileSave(change.uri);
     }
-    // When external map files change, revalidate all open documents
-    // (key space and cross-references may have changed)
-    if (classification.mapChanged) {
+    // When external DITA files change — topics as well as maps — revalidate
+    // all open documents. Cross-reference diagnostics for an open document
+    // depend on the *content* of whatever file its href/conref/conkeyref
+    // fragments resolve to; saving an unrelated topic (not just a map) can
+    // just as easily invalidate another open document's cached DITA-XREF-*/
+    // DITA-KEY-* results (e.g. an id was renamed or removed), so this must
+    // not be gated on mapChanged alone.
+    if (classification.ditaFileChanged) {
         validationPipeline.invalidateForMapChange();
         debouncedRefresh('__map_external__', MAP_DEBOUNCE_MS);
     }

--- a/server/src/services/keySpaceService.ts
+++ b/server/src/services/keySpaceService.ts
@@ -615,12 +615,25 @@ export class KeySpaceService implements IKeySpaceService {
         // descendant scope namespaces (e.g. "product.lib.version" from "product.version").
         const scopeDirectKeys = new Map<string, KeyDefinition[]>();
 
-        // Caches each map's own key definitions (and root @keyscope) the first time
-        // it is traversed, so a later encounter of the same map via a *different*
-        // mapref @keyscope (diamond-shaped scope graph) can still register that
-        // map's keys under the new scope namespace without re-parsing the file or
-        // re-queueing its submaps (which would already have been queued once).
-        const mapDirectKeysCache = new Map<string, { keys: KeyDefinition[]; rootScopes: string[] }>();
+        // Caches each map's own key definitions, root @keyscope, and submap
+        // references the first time it is traversed, so a later encounter of
+        // the same map via a *different* mapref @keyscope (diamond-shaped
+        // scope graph) can still register that map's keys — and re-queue its
+        // submaps — under the new scope namespace without re-parsing the file.
+        const mapDirectKeysCache = new Map<string, {
+            keys: KeyDefinition[];
+            rootScopes: string[];
+            submaps: { path: string; keyscopes: string[]; inlineKeys: string[]; isPeer: boolean }[];
+        }>();
+
+        // Tracks which effective scope-prefix combinations have already been
+        // registered for each map path, so a diamond graph that reaches the
+        // same map+scope combination more than once (including via cycles
+        // introduced by re-queueing submaps below) doesn't redo the same work
+        // or loop forever.
+        const registeredScopeSignatures = new Map<string, Set<string>>();
+        const scopeSignature = (prefixes: readonly string[]): string =>
+            [...prefixes].sort().join(' ');
 
         while (queue.length > 0) {
             const { mapPath: currentMap, scopePrefixes } = queue.shift()!;
@@ -628,10 +641,32 @@ export class KeySpaceService implements IKeySpaceService {
 
             if (visited.has(normalizedPath)) {
                 const cached = mapDirectKeysCache.get(normalizedPath);
-                if (cached) {
-                    this.registerKeysForAdditionalScope(
-                        keySpace, scopeDirectKeys, cached.keys, scopePrefixes, cached.rootScopes
+                if (!cached) continue;
+
+                const effectivePrefixes = this.combineScopePrefixes(scopePrefixes, cached.rootScopes);
+                const signature = scopeSignature(effectivePrefixes);
+                let seenSignatures = registeredScopeSignatures.get(normalizedPath);
+                if (!seenSignatures) {
+                    seenSignatures = new Set();
+                    registeredScopeSignatures.set(normalizedPath, seenSignatures);
+                }
+                if (seenSignatures.has(signature)) continue;
+                seenSignatures.add(signature);
+
+                this.registerKeysForAdditionalScope(
+                    keySpace, scopeDirectKeys, cached.keys, scopePrefixes, cached.rootScopes
+                );
+
+                // Re-queue this map's submaps under the new scope too — otherwise
+                // nested maps stay unresolvable under the second scope path even
+                // though they were already reachable under the first.
+                for (const submap of cached.submaps) {
+                    if (submap.isPeer) continue;
+                    const childPrefixes = this.combineScopePrefixes(effectivePrefixes, submap.keyscopes);
+                    this.registerInlineMaprefKeys(
+                        keySpace, scopeDirectKeys, submap.inlineKeys, currentMap, submap.path, childPrefixes
                     );
+                    queue.push({ mapPath: submap.path, scopePrefixes: childPrefixes });
                 }
                 continue;
             }
@@ -671,7 +706,12 @@ export class KeySpaceService implements IKeySpaceService {
                 );
 
                 const keys = this.extractKeyDefinitions(maskedContent, currentMap, maxLinkMatches);
-                mapDirectKeysCache.set(normalizedPath, { keys, rootScopes });
+                let seenSignatures = registeredScopeSignatures.get(normalizedPath);
+                if (!seenSignatures) {
+                    seenSignatures = new Set();
+                    registeredScopeSignatures.set(normalizedPath, seenSignatures);
+                }
+                seenSignatures.add(scopeSignature(effectivePrefixes));
                 for (const keyDef of keys) {
                     // Record as a direct key of every scope alias (first per key name wins).
                     for (const prefix of allScopePrefixes) {
@@ -714,6 +754,7 @@ export class KeySpaceService implements IKeySpaceService {
                 // queued again (processInlineScopeBlocks already queued them with the
                 // correct child scope prefix).
                 const submaps = this.extractMapReferences(maskedContent, currentMap, maxLinkMatches);
+                mapDirectKeysCache.set(normalizedPath, { keys, rootScopes, submaps });
                 for (const submap of submaps) {
                     // Peer maps are not inlined; register them for lazy resolution on key miss.
                     if (submap.isPeer) {
@@ -729,29 +770,9 @@ export class KeySpaceService implements IKeySpaceService {
 
                     // Register @keys defined on the mapref element itself under the child scope prefix.
                     // The mapref element is included in the child scope it creates (DITA spec §2.4.4.1).
-                    if (submap.inlineKeys.length > 0 && childPrefixes.length > 0) {
-                        for (const inlineKeyName of submap.inlineKeys) {
-                            const inlineDef: KeyDefinition = {
-                                keyName: inlineKeyName,
-                                sourceMap: currentMap,
-                                targetFile: submap.path,
-                            };
-                            for (const prefix of childPrefixes) {
-                                if (!scopeDirectKeys.has(prefix)) {
-                                    scopeDirectKeys.set(prefix, []);
-                                }
-                                const directKeys = scopeDirectKeys.get(prefix)!;
-                                if (!directKeys.some(k => k.keyName === inlineKeyName)) {
-                                    directKeys.push(inlineDef);
-                                }
-                                const qualifiedName = `${prefix}.${inlineKeyName}`;
-                                this.addScopedKeyEntry(keySpace, qualifiedName, { ...inlineDef, keyName: qualifiedName });
-                            }
-                            if (!keySpace.keys.has(inlineKeyName)) {
-                                keySpace.keys.set(inlineKeyName, inlineDef);
-                            }
-                        }
-                    }
+                    this.registerInlineMaprefKeys(
+                        keySpace, scopeDirectKeys, submap.inlineKeys, currentMap, submap.path, childPrefixes
+                    );
 
                     queue.push({ mapPath: submap.path, scopePrefixes: childPrefixes });
                 }
@@ -1401,6 +1422,46 @@ export class KeySpaceService implements IKeySpaceService {
 
     private isPathWithinWorkspace(absolutePath: string): boolean {
         return isPathWithinWorkspace(absolutePath, this.workspaceFolders);
+    }
+
+    /**
+     * Register the @keys defined directly on a `<mapref>` element (the
+     * mapref itself is included in the child scope it creates, per DITA spec
+     * §2.4.4.1) under the given child scope prefixes. Shared between the
+     * first traversal of a submap and any later diamond-shaped-scope-graph
+     * re-registration under a different scope path.
+     */
+    private registerInlineMaprefKeys(
+        keySpace: KeySpace,
+        scopeDirectKeys: Map<string, KeyDefinition[]>,
+        inlineKeys: string[],
+        sourceMap: string,
+        targetFile: string,
+        childPrefixes: string[]
+    ): void {
+        if (inlineKeys.length === 0 || childPrefixes.length === 0) return;
+
+        for (const inlineKeyName of inlineKeys) {
+            const inlineDef: KeyDefinition = {
+                keyName: inlineKeyName,
+                sourceMap,
+                targetFile,
+            };
+            for (const prefix of childPrefixes) {
+                if (!scopeDirectKeys.has(prefix)) {
+                    scopeDirectKeys.set(prefix, []);
+                }
+                const directKeys = scopeDirectKeys.get(prefix)!;
+                if (!directKeys.some(k => k.keyName === inlineKeyName)) {
+                    directKeys.push(inlineDef);
+                }
+                const qualifiedName = `${prefix}.${inlineKeyName}`;
+                this.addScopedKeyEntry(keySpace, qualifiedName, { ...inlineDef, keyName: qualifiedName });
+            }
+            if (!keySpace.keys.has(inlineKeyName)) {
+                keySpace.keys.set(inlineKeyName, inlineDef);
+            }
+        }
     }
 
     /**

--- a/server/src/services/keySpaceService.ts
+++ b/server/src/services/keySpaceService.ts
@@ -11,7 +11,7 @@ import { promises as fsPromises } from 'fs';
 
 import { XMLParser } from 'fast-xml-parser';
 import { TAG_ATTRS } from '../utils/patterns';
-import { stripCommentsAndCDATA } from '../utils/textUtils';
+import { stripCommentsAndCDATA, isPathWithinWorkspace } from '../utils/textUtils';
 import { IKeySpaceService } from './interfaces';
 
 // --- Interfaces ---
@@ -615,11 +615,26 @@ export class KeySpaceService implements IKeySpaceService {
         // descendant scope namespaces (e.g. "product.lib.version" from "product.version").
         const scopeDirectKeys = new Map<string, KeyDefinition[]>();
 
+        // Caches each map's own key definitions (and root @keyscope) the first time
+        // it is traversed, so a later encounter of the same map via a *different*
+        // mapref @keyscope (diamond-shaped scope graph) can still register that
+        // map's keys under the new scope namespace without re-parsing the file or
+        // re-queueing its submaps (which would already have been queued once).
+        const mapDirectKeysCache = new Map<string, { keys: KeyDefinition[]; rootScopes: string[] }>();
+
         while (queue.length > 0) {
             const { mapPath: currentMap, scopePrefixes } = queue.shift()!;
             const normalizedPath = path.normalize(currentMap);
 
-            if (visited.has(normalizedPath)) continue;
+            if (visited.has(normalizedPath)) {
+                const cached = mapDirectKeysCache.get(normalizedPath);
+                if (cached) {
+                    this.registerKeysForAdditionalScope(
+                        keySpace, scopeDirectKeys, cached.keys, scopePrefixes, cached.rootScopes
+                    );
+                }
+                continue;
+            }
 
             const fileExists = await this.fileExistsAsync(currentMap);
             if (!fileExists) continue;
@@ -656,6 +671,7 @@ export class KeySpaceService implements IKeySpaceService {
                 );
 
                 const keys = this.extractKeyDefinitions(maskedContent, currentMap, maxLinkMatches);
+                mapDirectKeysCache.set(normalizedPath, { keys, rootScopes });
                 for (const keyDef of keys) {
                     // Record as a direct key of every scope alias (first per key name wins).
                     for (const prefix of allScopePrefixes) {
@@ -1384,15 +1400,43 @@ export class KeySpaceService implements IKeySpaceService {
     }
 
     private isPathWithinWorkspace(absolutePath: string): boolean {
-        if (this.workspaceFolders.length === 0) {
-            return true; // No workspace — single file mode
+        return isPathWithinWorkspace(absolutePath, this.workspaceFolders);
+    }
+
+    /**
+     * Register a map's already-extracted key definitions under an additional
+     * scope-prefix combination reached via a second mapref in a diamond-shaped
+     * scope graph (e.g. the same submap included under both @keyscope="prodA"
+     * and @keyscope="prodB"). Only populates scope-qualified aliases — the
+     * unqualified `keySpace.keys`/`duplicateKeys` bookkeeping already happened
+     * when the map was first traversed and must not be repeated here.
+     */
+    private registerKeysForAdditionalScope(
+        keySpace: KeySpace,
+        scopeDirectKeys: Map<string, KeyDefinition[]>,
+        keys: KeyDefinition[],
+        scopePrefixes: string[],
+        rootScopes: string[]
+    ): void {
+        const effectivePrefixes = this.combineScopePrefixes(scopePrefixes, rootScopes);
+        if (effectivePrefixes.length === 0) return;
+
+        for (const prefix of effectivePrefixes) {
+            if (!scopeDirectKeys.has(prefix)) {
+                scopeDirectKeys.set(prefix, []);
+            }
         }
 
-        const normalizedPath = path.normalize(absolutePath);
-        return this.workspaceFolders.some(folder => {
-            const normalizedWorkspace = path.normalize(folder);
-            return normalizedPath.startsWith(normalizedWorkspace + path.sep);
-        });
+        for (const keyDef of keys) {
+            for (const prefix of effectivePrefixes) {
+                const directKeys = scopeDirectKeys.get(prefix)!;
+                if (!directKeys.some(k => k.keyName === keyDef.keyName)) {
+                    directKeys.push(keyDef);
+                }
+                const qualifiedName = `${prefix}.${keyDef.keyName}`;
+                this.addScopedKeyEntry(keySpace, qualifiedName, { ...keyDef, keyName: qualifiedName });
+            }
+        }
     }
 
     /**

--- a/server/src/services/keySpaceService.ts
+++ b/server/src/services/keySpaceService.ts
@@ -11,7 +11,7 @@ import { promises as fsPromises } from 'fs';
 
 import { XMLParser } from 'fast-xml-parser';
 import { TAG_ATTRS } from '../utils/patterns';
-import { stripCommentsAndCDATA, isPathWithinWorkspace } from '../utils/textUtils';
+import { stripCommentsAndCDATA, isPathWithinWorkspace, normalizeFsPath } from '../utils/textUtils';
 import { IKeySpaceService } from './interfaces';
 
 // --- Interfaces ---
@@ -213,7 +213,7 @@ export class KeySpaceService implements IKeySpaceService {
         // the root-level unqualified key ("version").  The PushDown pass has already
         // added inherited ancestor keys under the child scope namespace, so a child
         // scope override always beats an ancestor definition at this lookup point.
-        const scopePrefix = keySpace.topicToScope.get(path.normalize(contextFilePath));
+        const scopePrefix = keySpace.topicToScope.get(normalizeFsPath(contextFilePath));
         if (scopePrefix) {
             const qualifiedName = `${scopePrefix}.${keyName}`;
             const scopedDef = keySpace.keys.get(qualifiedName);
@@ -289,7 +289,7 @@ export class KeySpaceService implements IKeySpaceService {
         const keySpace = await this.buildKeySpace(rootMap);
 
         // Step 1 — context-aware scope lookup
-        const scopePrefix = keySpace.topicToScope.get(path.normalize(contextFilePath));
+        const scopePrefix = keySpace.topicToScope.get(normalizeFsPath(contextFilePath));
         if (scopePrefix) {
             report.contextScope = scopePrefix;
             const qualifiedName = `${scopePrefix}.${keyName}`;
@@ -637,7 +637,7 @@ export class KeySpaceService implements IKeySpaceService {
 
         while (queue.length > 0) {
             const { mapPath: currentMap, scopePrefixes } = queue.shift()!;
-            const normalizedPath = path.normalize(currentMap);
+            const normalizedPath = normalizeFsPath(currentMap);
 
             if (visited.has(normalizedPath)) {
                 const cached = mapDirectKeysCache.get(normalizedPath);
@@ -1289,7 +1289,7 @@ export class KeySpaceService implements IKeySpaceService {
             if (href.startsWith('http://') || href.startsWith('https://')) continue;
             const resolved = path.resolve(mapDir, href);
             if (!this.isPathWithinWorkspace(resolved)) continue;
-            const normalized = path.normalize(resolved);
+            const normalized = normalizeFsPath(resolved);
             if (!topicToScope.has(normalized)) {
                 topicToScope.set(normalized, scopePrefix);
             }
@@ -1406,14 +1406,14 @@ export class KeySpaceService implements IKeySpaceService {
     // --- Internal: Helpers ---
 
     private doInvalidate(changedFile: string): void {
-        const normalizedPath = path.normalize(changedFile);
+        const normalizedPath = normalizeFsPath(changedFile);
         const changedDir = path.dirname(normalizedPath);
 
         this.rootMapCache.delete(changedDir);
 
         const toDelete: string[] = [];
         for (const [rootMap, keySpace] of this.keySpaceCache.entries()) {
-            if (keySpace.mapHierarchy.some(m => path.normalize(m) === normalizedPath)) {
+            if (keySpace.mapHierarchy.some(m => normalizeFsPath(m) === normalizedPath)) {
                 toDelete.push(rootMap);
             }
         }

--- a/server/src/services/validationPipeline.ts
+++ b/server/src/services/validationPipeline.ts
@@ -15,7 +15,7 @@ import { TextDocument } from 'vscode-languageserver-textdocument';
 import { CancellationToken } from 'vscode-languageserver';
 
 import { DitaCraftSettings } from '../settings';
-import { normalizeFsPath, uriToPath } from '../utils/textUtils';
+import { normalizeFsPath, uriToPath, effectiveWorkspaceFolders } from '../utils/textUtils';
 import { t } from '../utils/i18n';
 import { validateDITADocument } from '../features/validation';
 import { validateContentModel } from '../features/contentModelValidation';
@@ -562,7 +562,10 @@ export class ValidationPipeline {
                 try {
                     const cycleDiags = await timePhaseAsync('CircularRef', () =>
                         withTimeout(
-                            detectCircularReferences(text, uri, keySpaceService?.getWorkspaceFolders() ?? []),
+                            detectCircularReferences(
+                                text, uri,
+                                effectiveWorkspaceFolders(filePath, keySpaceService?.getWorkspaceFolders() ?? [])
+                            ),
                             phaseTimeoutMs, 'CircularRef', [] as Diagnostic[], this.log, token,
                         )
                     );

--- a/server/src/services/validationPipeline.ts
+++ b/server/src/services/validationPipeline.ts
@@ -562,7 +562,7 @@ export class ValidationPipeline {
                 try {
                     const cycleDiags = await timePhaseAsync('CircularRef', () =>
                         withTimeout(
-                            detectCircularReferences(text, uri),
+                            detectCircularReferences(text, uri, keySpaceService?.getWorkspaceFolders() ?? []),
                             phaseTimeoutMs, 'CircularRef', [] as Diagnostic[], this.log, token,
                         )
                     );

--- a/server/src/settings.ts
+++ b/server/src/settings.ts
@@ -95,7 +95,14 @@ export function getDocumentSettings(resource: string): Thenable<DitaCraftSetting
         }).then((conf: Partial<DitaCraftSettings>) => ({
             ...defaultSettings,
             ...conf,
-        }));
+        })).catch(() => {
+            // A transient failure (client error, timeout, malformed response)
+            // must not permanently poison this resource's cache entry with a
+            // forever-rejected promise — evict it so the next call retries,
+            // and fall back to defaults for this call.
+            documentSettings.delete(resource);
+            return defaultSettings;
+        });
         documentSettings.set(resource, result);
     }
     return result;

--- a/server/src/utils/tagStack.ts
+++ b/server/src/utils/tagStack.ts
@@ -1,0 +1,38 @@
+/**
+ * Resync a name-keyed element stack against a closing tag.
+ *
+ * A closing tag is meant to pop the stack entry it matches. But when an
+ * earlier closing tag was mismatched or missing, entries above the intended
+ * match were never popped. Removing only the matched entry in that case
+ * leaves those stale ancestors on the stack, desyncing every subsequent
+ * lookup for the rest of the document (wrong parent/container, corrupted
+ * nesting, wrong fold ranges, etc.). Truncating the stack through and
+ * including the match discards them too.
+ *
+ * Searches from the top of the stack down. If a match is found, `onDiscard`
+ * (if given) is invoked once per discarded entry, from the top down through
+ * the match, before the stack is truncated — `isMatch` is `true` only for
+ * the matched entry itself. If no match is found, the stack is left
+ * untouched (a stray closing tag with no open ancestor).
+ *
+ * Returns the matched index, or -1 if nothing matched.
+ */
+export function resyncStackToMatch<T>(
+    stack: T[],
+    name: string,
+    getName: (item: T) => string,
+    onDiscard?: (item: T, index: number, isMatch: boolean) => void
+): number {
+    for (let i = stack.length - 1; i >= 0; i--) {
+        if (getName(stack[i]) === name) {
+            if (onDiscard) {
+                for (let k = stack.length - 1; k >= i; k--) {
+                    onDiscard(stack[k], k, k === i);
+                }
+            }
+            stack.length = i;
+            return i;
+        }
+    }
+    return -1;
+}

--- a/server/src/utils/textUtils.ts
+++ b/server/src/utils/textUtils.ts
@@ -130,9 +130,14 @@ export function isPathWithinWorkspace(absolutePath: string, workspaceFolders: re
         return true;
     }
 
-    const normalizedPath = path.normalize(absolutePath);
+    // Use normalizeFsPath (not a bare path.normalize) so this comparison is
+    // case-insensitive on Windows — otherwise two paths that refer to the
+    // same file but were derived through different code paths (e.g. one via
+    // a file:// URI round-trip, which vscode-uri lowercases the drive letter
+    // of, and one from a raw fs path) would wrongly compare as different.
+    const normalizedPath = normalizeFsPath(absolutePath);
     return workspaceFolders.some(folder => {
-        const normalizedWorkspace = path.normalize(folder);
+        const normalizedWorkspace = normalizeFsPath(folder);
         return normalizedPath === normalizedWorkspace ||
             normalizedPath.startsWith(normalizedWorkspace + path.sep);
     });

--- a/server/src/utils/textUtils.ts
+++ b/server/src/utils/textUtils.ts
@@ -144,6 +144,30 @@ export function isPathWithinWorkspace(absolutePath: string, workspaceFolders: re
 }
 
 /**
+ * Compute the workspace-folder list to actually enforce boundaries against
+ * for a given document.
+ *
+ * If the document itself isn't inside any of the configured workspace
+ * folders (e.g. a loose file opened via File > Open while a different
+ * project folder is the active workspace), there is no workspace boundary
+ * to enforce for *that document* — treating it as bounded by folders it
+ * isn't even part of would block every relative reference it makes,
+ * including trivial same-directory siblings. In that case this returns an
+ * empty list, which isPathWithinWorkspace treats as single-file mode
+ * (always permissive), matching how the document would behave if no
+ * workspace were open at all.
+ */
+export function effectiveWorkspaceFolders(
+    documentPath: string,
+    workspaceFolders: readonly string[]
+): readonly string[] {
+    if (workspaceFolders.length === 0) {
+        return workspaceFolders;
+    }
+    return isPathWithinWorkspace(documentPath, workspaceFolders) ? workspaceFolders : [];
+}
+
+/**
  * Escape special regex characters in a string for use in `new RegExp(...)`.
  */
 export function escapeRegex(str: string): string {

--- a/server/src/utils/textUtils.ts
+++ b/server/src/utils/textUtils.ts
@@ -115,6 +115,30 @@ export function normalizeFsPath(filePath: string): string {
 }
 
 /**
+ * Check whether an absolute path resolves inside one of the given workspace
+ * folders. Use this after every `path.resolve()` of a user-authored `href`,
+ * `conref`, `conkeyref`, or similar reference before touching the filesystem
+ * (`fs.readFile`, `fs.readdir`, `fs.access`, etc.), so a relative path that
+ * escapes the workspace (e.g. `href="../../../../etc/passwd"`) cannot be used
+ * to read or list files outside it.
+ *
+ * Returns `true` when `workspaceFolders` is empty (single-file mode, no
+ * workspace boundary to enforce).
+ */
+export function isPathWithinWorkspace(absolutePath: string, workspaceFolders: readonly string[]): boolean {
+    if (workspaceFolders.length === 0) {
+        return true;
+    }
+
+    const normalizedPath = path.normalize(absolutePath);
+    return workspaceFolders.some(folder => {
+        const normalizedWorkspace = path.normalize(folder);
+        return normalizedPath === normalizedWorkspace ||
+            normalizedPath.startsWith(normalizedWorkspace + path.sep);
+    });
+}
+
+/**
  * Escape special regex characters in a string for use in `new RegExp(...)`.
  */
 export function escapeRegex(str: string): string {

--- a/server/src/utils/workspaceScanner.ts
+++ b/server/src/utils/workspaceScanner.ts
@@ -99,7 +99,8 @@ export async function findCrossFileReferences(
     workspaceFolders: readonly string[],
     excludeUri?: string,
     documents?: TextDocuments<TextDocument>,
-    keySpaceService?: KeySpaceService
+    keySpaceService?: KeySpaceService,
+    log?: (msg: string) => void
 ): Promise<Location[]> {
     const results: Location[] = [];
     const ditaFiles = collectDitaFiles(workspaceFolders);
@@ -149,7 +150,13 @@ export async function findCrossFileReferences(
                     }
                 }
             } else if (ref.type === 'conkeyref') {
-                if (!keySpaceService) continue;
+                if (!keySpaceService) {
+                    log?.(
+                        `Skipping unverifiable conkeyref "${ref.value}" in ${filePath} ` +
+                        '(no KeySpaceService available to resolve the key target)'
+                    );
+                    continue;
+                }
                 const slashIdx = ref.value.indexOf('/');
                 const keyName = slashIdx >= 0 ? ref.value.slice(0, slashIdx) : ref.value;
                 const keyDef = await keySpaceService.resolveKey(keyName, filePath);

--- a/server/src/utils/workspaceScanner.ts
+++ b/server/src/utils/workspaceScanner.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import { Location, TextDocuments } from 'vscode-languageserver/node';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { URI } from 'vscode-uri';
-import { findReferencesToId, parseReference } from './referenceParser';
+import { findReferencesToId, parseReference, ReferenceOccurrence } from './referenceParser';
 import { offsetToPosition, normalizeFsPath } from './textUtils';
 import { KeySpaceService } from '../services/keySpaceService';
 
@@ -83,6 +83,56 @@ export async function collectDitaFilesAsync(workspaceFolders: readonly string[])
 }
 
 /**
+ * Test whether a single reference occurrence found in `contextFilePath`
+ * actually targets `normalizedTargetPath`.
+ *
+ * - href/conref with a file part: matches only if that path resolves to the target.
+ * - href/conref fragment-only (e.g. "#topicid"): matches only if contextFilePath
+ *   IS the target file itself.
+ * - conkeyref: the key must be resolved via keySpaceService to know which file it
+ *   targets; without one this cannot be verified, so it's excluded (and logged via
+ *   `log`, if given) rather than matched by element-ID text alone, which can
+ *   false-positive on an unrelated file whose element merely shares the same id.
+ * - keyref (no element-id sub-part): always matches — there is no file part to
+ *   verify against.
+ *
+ * Shared by rename.ts, references.ts, and findCrossFileReferences below so the
+ * same matching rules apply consistently across Rename, Find All References,
+ * and cross-file reference scanning.
+ */
+export async function referenceMatchesTarget(
+    ref: ReferenceOccurrence,
+    contextFilePath: string,
+    normalizedTargetPath: string,
+    keySpaceService: KeySpaceService | undefined,
+    log?: (msg: string) => void
+): Promise<boolean> {
+    if (ref.type === 'href' || ref.type === 'conref') {
+        const parsed = parseReference(ref.value);
+        if (parsed.filePath) {
+            const resolvedPath = normalizeFsPath(path.resolve(path.dirname(contextFilePath), parsed.filePath));
+            return resolvedPath === normalizedTargetPath;
+        }
+        return normalizeFsPath(contextFilePath) === normalizedTargetPath;
+    }
+    if (ref.type === 'conkeyref') {
+        if (!keySpaceService) {
+            log?.(
+                `Skipping unverifiable conkeyref "${ref.value}" in ${contextFilePath} ` +
+                '(no KeySpaceService available to resolve the key target)'
+            );
+            return false;
+        }
+        const slashIdx = ref.value.indexOf('/');
+        const keyName = slashIdx >= 0 ? ref.value.slice(0, slashIdx) : ref.value;
+        const keyDef = await keySpaceService.resolveKey(keyName, contextFilePath);
+        const resolvedTarget = keyDef?.targetFile ? normalizeFsPath(keyDef.targetFile) : null;
+        return resolvedTarget === normalizedTargetPath;
+    }
+    return true;
+}
+
+/**
  * Find all references to a target ID across all DITA files in the workspace.
  *
  * Filtering:
@@ -130,39 +180,11 @@ export async function findCrossFileReferences(
         const refs = findReferencesToId(content, targetId);
         if (refs.length === 0) continue;
 
-        const fileDir = path.dirname(filePath);
-
         for (const ref of refs) {
-            if (ref.type === 'href' || ref.type === 'conref') {
-                const parsed = parseReference(ref.value);
-                if (parsed.filePath) {
-                    // Cross-file ref: check path resolves to target
-                    const resolvedPath = normalizeFsPath(
-                        path.resolve(fileDir, parsed.filePath)
-                    );
-                    if (resolvedPath !== normalizedTargetPath) {
-                        continue;
-                    }
-                } else {
-                    // Fragment-only ref: only relevant if in the target file itself
-                    if (normalizeFsPath(filePath) !== normalizedTargetPath) {
-                        continue;
-                    }
-                }
-            } else if (ref.type === 'conkeyref') {
-                if (!keySpaceService) {
-                    log?.(
-                        `Skipping unverifiable conkeyref "${ref.value}" in ${filePath} ` +
-                        '(no KeySpaceService available to resolve the key target)'
-                    );
-                    continue;
-                }
-                const slashIdx = ref.value.indexOf('/');
-                const keyName = slashIdx >= 0 ? ref.value.slice(0, slashIdx) : ref.value;
-                const keyDef = await keySpaceService.resolveKey(keyName, filePath);
-                const resolvedTarget = keyDef?.targetFile ? normalizeFsPath(keyDef.targetFile) : null;
-                if (resolvedTarget !== normalizedTargetPath) continue;
-            }
+            const matches = await referenceMatchesTarget(
+                ref, filePath, normalizedTargetPath, keySpaceService, log
+            );
+            if (!matches) continue;
 
             const startPos = offsetToPosition(content, ref.valueStart);
             const endPos = offsetToPosition(content, ref.valueEnd);

--- a/server/src/utils/workspaceScanner.ts
+++ b/server/src/utils/workspaceScanner.ts
@@ -152,16 +152,20 @@ export async function findCrossFileReferences(
     keySpaceService?: KeySpaceService,
     log?: (msg: string) => void
 ): Promise<Location[]> {
-    const results: Location[] = [];
     const ditaFiles = collectDitaFiles(workspaceFolders);
     const normalizedTargetPath = normalizeFsPath(targetFilePath);
 
-    for (const filePath of ditaFiles) {
+    // Each file's conkeyref matches are resolved concurrently (KeySpaceService
+    // dedupes concurrent builds of the same key space via pendingBuilds), then
+    // files themselves are processed concurrently too. Promise.all preserves
+    // input order, so results come back in the same order as sequential
+    // processing would have produced.
+    const perFileResults = await Promise.all(ditaFiles.map(async (filePath): Promise<Location[]> => {
         const fileUri = URI.file(filePath).toString();
 
         // Skip the current document (already searched by the caller)
         if (excludeUri && fileUri === excludeUri) {
-            continue;
+            return [];
         }
 
         // Prefer in-memory content for open documents (may have unsaved changes)
@@ -173,24 +177,26 @@ export async function findCrossFileReferences(
             try {
                 content = fs.readFileSync(filePath, 'utf-8');
             } catch {
-                continue;
+                return [];
             }
         }
 
         const refs = findReferencesToId(content, targetId);
-        if (refs.length === 0) continue;
+        if (refs.length === 0) return [];
 
-        for (const ref of refs) {
-            const matches = await referenceMatchesTarget(
-                ref, filePath, normalizedTargetPath, keySpaceService, log
-            );
-            if (!matches) continue;
+        const matchFlags = await Promise.all(
+            refs.map(ref => referenceMatchesTarget(ref, filePath, normalizedTargetPath, keySpaceService, log))
+        );
 
+        const fileResults: Location[] = [];
+        refs.forEach((ref, i) => {
+            if (!matchFlags[i]) return;
             const startPos = offsetToPosition(content, ref.valueStart);
             const endPos = offsetToPosition(content, ref.valueEnd);
-            results.push(Location.create(fileUri, { start: startPos, end: endPos }));
-        }
-    }
+            fileResults.push(Location.create(fileUri, { start: startPos, end: endPos }));
+        });
+        return fileResults;
+    }));
 
-    return results;
+    return perFileResults.flat();
 }

--- a/server/src/utils/workspaceScanner.ts
+++ b/server/src/utils/workspaceScanner.ts
@@ -6,6 +6,7 @@ import { TextDocument } from 'vscode-languageserver-textdocument';
 import { URI } from 'vscode-uri';
 import { findReferencesToId, parseReference } from './referenceParser';
 import { offsetToPosition } from './textUtils';
+import { KeySpaceService } from '../services/keySpaceService';
 
 /** File extensions considered DITA files. */
 const DITA_EXTENSIONS = new Set(['.dita', '.ditamap', '.bookmap']);
@@ -87,15 +88,19 @@ export async function collectDitaFilesAsync(workspaceFolders: readonly string[])
  * Filtering:
  * - href/conref with file path: only included if the path resolves to targetFilePath
  * - href/conref fragment-only: only included if found in the target file itself
- * - conkeyref: included by element ID match (cannot resolve key synchronously)
+ * - conkeyref: only included if its key resolves (via keySpaceService) to targetFilePath;
+ *   without a keySpaceService this cannot be verified, so conkeyref matches are excluded
+ *   rather than reported by element-ID text match alone (which can false-positive on an
+ *   unrelated file whose element merely shares the same id)
  */
-export function findCrossFileReferences(
+export async function findCrossFileReferences(
     targetId: string,
     targetFilePath: string,
     workspaceFolders: readonly string[],
     excludeUri?: string,
-    documents?: TextDocuments<TextDocument>
-): Location[] {
+    documents?: TextDocuments<TextDocument>,
+    keySpaceService?: KeySpaceService
+): Promise<Location[]> {
     const results: Location[] = [];
     const ditaFiles = collectDitaFiles(workspaceFolders);
     const normalizedTargetPath = path.normalize(targetFilePath);
@@ -143,8 +148,14 @@ export function findCrossFileReferences(
                         continue;
                     }
                 }
+            } else if (ref.type === 'conkeyref') {
+                if (!keySpaceService) continue;
+                const slashIdx = ref.value.indexOf('/');
+                const keyName = slashIdx >= 0 ? ref.value.slice(0, slashIdx) : ref.value;
+                const keyDef = await keySpaceService.resolveKey(keyName, filePath);
+                const resolvedTarget = keyDef?.targetFile ? path.normalize(keyDef.targetFile) : null;
+                if (resolvedTarget !== normalizedTargetPath) continue;
             }
-            // conkeyref: include all matches by element ID
 
             const startPos = offsetToPosition(content, ref.valueStart);
             const endPos = offsetToPosition(content, ref.valueEnd);

--- a/server/src/utils/workspaceScanner.ts
+++ b/server/src/utils/workspaceScanner.ts
@@ -5,7 +5,7 @@ import { Location, TextDocuments } from 'vscode-languageserver/node';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { URI } from 'vscode-uri';
 import { findReferencesToId, parseReference } from './referenceParser';
-import { offsetToPosition } from './textUtils';
+import { offsetToPosition, normalizeFsPath } from './textUtils';
 import { KeySpaceService } from '../services/keySpaceService';
 
 /** File extensions considered DITA files. */
@@ -103,7 +103,7 @@ export async function findCrossFileReferences(
 ): Promise<Location[]> {
     const results: Location[] = [];
     const ditaFiles = collectDitaFiles(workspaceFolders);
-    const normalizedTargetPath = path.normalize(targetFilePath);
+    const normalizedTargetPath = normalizeFsPath(targetFilePath);
 
     for (const filePath of ditaFiles) {
         const fileUri = URI.file(filePath).toString();
@@ -136,7 +136,7 @@ export async function findCrossFileReferences(
                 const parsed = parseReference(ref.value);
                 if (parsed.filePath) {
                     // Cross-file ref: check path resolves to target
-                    const resolvedPath = path.normalize(
+                    const resolvedPath = normalizeFsPath(
                         path.resolve(fileDir, parsed.filePath)
                     );
                     if (resolvedPath !== normalizedTargetPath) {
@@ -144,7 +144,7 @@ export async function findCrossFileReferences(
                     }
                 } else {
                     // Fragment-only ref: only relevant if in the target file itself
-                    if (path.normalize(filePath) !== normalizedTargetPath) {
+                    if (normalizeFsPath(filePath) !== normalizedTargetPath) {
                         continue;
                     }
                 }
@@ -153,7 +153,7 @@ export async function findCrossFileReferences(
                 const slashIdx = ref.value.indexOf('/');
                 const keyName = slashIdx >= 0 ? ref.value.slice(0, slashIdx) : ref.value;
                 const keyDef = await keySpaceService.resolveKey(keyName, filePath);
-                const resolvedTarget = keyDef?.targetFile ? path.normalize(keyDef.targetFile) : null;
+                const resolvedTarget = keyDef?.targetFile ? normalizeFsPath(keyDef.targetFile) : null;
                 if (resolvedTarget !== normalizedTargetPath) continue;
             }
 

--- a/server/test/circularRefDetection.test.ts
+++ b/server/test/circularRefDetection.test.ts
@@ -59,6 +59,34 @@ suite('detectCircularReferences', () => {
         }
     });
 
+    test('reference escaping the workspace is not followed even if it would close a cycle', async () => {
+        // A.ditamap (inside workspaceRoot/docs) references "../../outside.ditamap",
+        // which escapes workspaceRoot into a sibling directory. outside.ditamap
+        // references back to A.ditamap, which would form a cycle if the escaping
+        // reference were followed. With a workspace boundary supplied, DFS must
+        // never leave the workspace, so no cycle should be reported.
+        const workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ditacraft-ws-'));
+        const docsDir = path.join(workspaceRoot, 'docs');
+        fs.mkdirSync(docsDir);
+        const fileA = path.join(docsDir, 'A.ditamap');
+        const outsideFile = path.join(os.tmpdir(), 'outside.ditamap');
+
+        fs.writeFileSync(fileA, '<map><topicref href="../../outside.ditamap"/></map>');
+        fs.writeFileSync(outsideFile, `<map><topicref href="${fileA.replace(/\\/g, '/')}"/></map>`);
+
+        const textA = fs.readFileSync(fileA, 'utf-8');
+        const uriA = URI.file(fileA).toString();
+
+        try {
+            const diags = await detectCircularReferences(textA, uriA, [workspaceRoot]);
+            const cycleDiags = diags.filter(d => d.code === CYCLE_CODES.CIRCULAR_REF);
+            assert.strictEqual(cycleDiags.length, 0, 'escaping reference must not be followed');
+        } finally {
+            fs.rmSync(workspaceRoot, { recursive: true, force: true });
+            fs.rmSync(outsideFile, { force: true });
+        }
+    });
+
     test('self-reference via href produces CIRCULAR_REF diagnostic', async () => {
         const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ditacraft-test-'));
         const fileA = path.join(tmpDir, 'self.ditamap');

--- a/server/test/codeActions.test.ts
+++ b/server/test/codeActions.test.ts
@@ -219,10 +219,19 @@ suite('handleCodeActions', () => {
     });
 
     suite('DITA-SCH-011: Convert alt attribute to element', () => {
+        // The real validator (ditaRulesValidator.ts, DITA-SCH-011) points the
+        // diagnostic range at the alt="..." attribute itself, not at the
+        // <image tag start — these tests mirror that so they actually
+        // exercise the same code path a real diagnostic would.
+        function altAttrDiag(content: string): Diagnostic {
+            const altOffset = content.indexOf('alt=');
+            const altMatch = content.slice(altOffset).match(/alt\s*=\s*["'][^"']*["']/)!;
+            return makeDiag('DITA-SCH-011', 0, altOffset, 0, altOffset + altMatch[0].length, 'dita-rules');
+        }
+
         test('offers fix for self-closing image with alt attribute', () => {
             const content = '<image href="pic.png" alt="A photo"/>';
-            const diag = makeDiag('DITA-SCH-011', 0, 0, 0, content.length, 'dita-rules');
-            const result = actions(content, [diag]);
+            const result = actions(content, [altAttrDiag(content)]);
             assert.ok(result.length > 0);
             assert.ok(result[0].title.includes('Convert'));
             const edits = result[0].edit!.changes![TEST_URI];
@@ -234,12 +243,27 @@ suite('handleCodeActions', () => {
 
         test('offers fix for open/close image with alt attribute', () => {
             const content = '<image href="pic.png" alt="A photo"></image>';
-            const diag = makeDiag('DITA-SCH-011', 0, 0, 0, content.length, 'dita-rules');
-            const result = actions(content, [diag]);
+            const result = actions(content, [altAttrDiag(content)]);
             assert.ok(result.length > 0);
             const edits = result[0].edit!.changes![TEST_URI];
             const allNewText = edits.map(e => e.newText).join('');
             assert.ok(allNewText.includes('<alt>A photo</alt>'));
+        });
+
+        test('fixes the diagnosed image, not a later one with its own alt attribute (regression)', () => {
+            // Two images, each with a deprecated alt attribute. Fixing the
+            // FIRST one's diagnostic must not touch the second image at all —
+            // before the fix, searching forward from the attribute offset
+            // skipped past the first <image and matched the second instead.
+            const content =
+                '<p><image href="a.png" alt="Foo"/></p>' +
+                '<p><image href="b.png" alt="Bar"/></p>';
+            const result = actions(content, [altAttrDiag(content)]);
+            assert.ok(result.length > 0);
+            const edits = result[0].edit!.changes![TEST_URI];
+            const allNewText = edits.map(e => e.newText).join('');
+            assert.ok(allNewText.includes('Foo'), 'should convert the diagnosed (first) image\'s alt value');
+            assert.ok(!allNewText.includes('Bar'), 'must not touch the second image\'s alt value');
         });
     });
 

--- a/server/test/completion.test.ts
+++ b/server/test/completion.test.ts
@@ -46,6 +46,20 @@ suite('handleCompletion', () => {
             const items = await complete(content, 0, 18);
             assert.strictEqual(items.length, 0);
         });
+
+        test('mismatched closing tag does not corrupt parent-element lookup (regression)', async () => {
+            // <b> is never properly closed — </p> is a mismatch that must
+            // resync findParentElement's stack by closing both <p> and <b>.
+            // Without that, the stack is left with <topic, b> after </body>
+            // (since </body> only pops the entry it actually matches), and
+            // the trailing < would incorrectly offer <b>'s children (none)
+            // instead of <topic>'s.
+            const content = '<topic><body><p><b>text</p></body><';
+            const items = await complete(content, 0, content.length);
+            const labels = items.map(i => i.label);
+            assert.ok(labels.includes('title'),
+                'parent should resolve to <topic> (offering its children), not the stuck <b>');
+        });
     });
 
     suite('Attribute completions', () => {

--- a/server/test/completion.test.ts
+++ b/server/test/completion.test.ts
@@ -493,6 +493,39 @@ suite('handleCompletion', () => {
             }
         });
 
+        test('href traversal escaping the workspace returns no completions', async () => {
+            // workspaceRoot/docs/source.dita, with href="../../" attempting to list
+            // the directory two levels up (outside workspaceRoot entirely). A
+            // workspace-scoped KeySpaceService must block the readdir rather than
+            // enumerate files outside the workspace.
+            const workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ditacraft-ws-'));
+            const docsDir = path.join(workspaceRoot, 'docs');
+            fs.mkdirSync(docsDir);
+            fs.writeFileSync(path.join(os.tmpdir(), 'outside-secret.dita'), '<topic id="s"/>');
+
+            try {
+                const testUri = URI.file(path.join(docsDir, 'source.dita')).toString();
+                const content = '<xref href="../../">';
+                const doc = createDoc(content, testUri);
+                const docs = createDocs(doc);
+
+                const mockKeySpaceService = {
+                    getWorkspaceFolders: () => [workspaceRoot],
+                } as unknown as KeySpaceService;
+
+                const items = await handleCompletion(
+                    { textDocument: { uri: testUri }, position: { line: 0, character: 18 } },
+                    docs,
+                    mockKeySpaceService
+                );
+
+                assert.strictEqual(items.length, 0, 'escaping traversal should yield no completions');
+            } finally {
+                fs.rmSync(workspaceRoot, { recursive: true, force: true });
+                fs.rmSync(path.join(os.tmpdir(), 'outside-secret.dita'), { force: true });
+            }
+        });
+
         test('conref lists .dita files too', async () => {
             const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ditacraft-test-'));
             fs.writeFileSync(path.join(tmpDir, 'shared.dita'), '<topic id="t1"/>');

--- a/server/test/contentModelValidation.test.ts
+++ b/server/test/contentModelValidation.test.ts
@@ -206,6 +206,40 @@ suite('Content Model Validation (server-side)', () => {
     });
 
     // -----------------------------------------------------------------------
+    suite('Mismatched closing tags', () => {
+
+        test('stray mismatched closing tag does not desync sibling validation', () => {
+            // </wrongname> has no matching ancestor on the stack (root is <topic>,
+            // then <body>) so it must be ignored rather than popping <body> off
+            // the stack. If it desynced, the real <body> content below would be
+            // misattributed as a child of <topic> and the <p> shouldn't be flagged.
+            const xml =
+                '<topic id="t"><title>T</title><body></wrongname><p>Ok</p></body></topic>';
+            const diags = validateContentModel(xml);
+            const parseErrors = diags.filter(d => d.code === 'DITA-CM-PARSE');
+            assert.ok(parseErrors.length > 0, 'should report the mismatched closing tag');
+
+            const cmErrors = diags.filter(d => d.code === 'DITA-CM-001');
+            assert.strictEqual(cmErrors.length, 0, '<p> inside <body> should remain valid after resync');
+        });
+
+        test('mismatched closing tag resyncs to matching ancestor instead of desyncing the tree', () => {
+            // <note> is closed with </p> by mistake (matching ancestor is <p>,
+            // two levels down: body > p > note). Resync should pop through <p>,
+            // closing both <note> and <p>, then <ul> should still validate as a
+            // child of <body>, not get nested under a corrupted <p>.
+            const xml =
+                '<topic id="t"><title>T</title><body><p><note>N</p><ul><li>x</li></ul></body></topic>';
+            const diags = validateContentModel(xml);
+            const parseErrors = diags.filter(d => d.code === 'DITA-CM-PARSE');
+            assert.ok(parseErrors.length > 0, 'should report the mismatched closing tag');
+
+            const cmErrors = diags.filter(d => d.code === 'DITA-CM-001');
+            assert.strictEqual(cmErrors.length, 0, '<ul> should validate as a child of <body>, not <p>');
+        });
+    });
+
+    // -----------------------------------------------------------------------
     suite('Glossentry', () => {
 
         test('glossentry with <body> reports error', () => {

--- a/server/test/contentModelValidation.test.ts
+++ b/server/test/contentModelValidation.test.ts
@@ -101,6 +101,23 @@ suite('Content Model Validation (server-side)', () => {
             assert.strictEqual(cmErrors.length, 0);
         });
 
+        test('body with <parml>, <screen>, <syntaxdiagram> is valid (regression)', () => {
+            // These are all listed as valid <body>/<section> children in
+            // ditaSchema.ts (DITA_ELEMENTS), which drives autocomplete — the
+            // content model validator must agree, or accepting the tool's own
+            // completion suggestion immediately produces a false-positive
+            // DITA-CM-001/003 diagnostic.
+            const xml =
+                '<topic id="t1"><title>T</title><body>' +
+                '<parml><plentry><pt>x</pt><pd>y</pd></plentry></parml>' +
+                '<screen>code</screen>' +
+                '<syntaxdiagram>diagram</syntaxdiagram>' +
+                '</body></topic>';
+            const diags = validateContentModel(xml);
+            const cmErrors = diags.filter(d => d.code === 'DITA-CM-001' || d.code === 'DITA-CM-003');
+            assert.deepStrictEqual(cmErrors, []);
+        });
+
         test('body with <topicref> reports error', () => {
             const xml = '<topic id="t1"><title>T</title><body><topicref href="a.dita"/></body></topic>';
             const diags = validateContentModel(xml);
@@ -144,6 +161,18 @@ suite('Content Model Validation (server-side)', () => {
             const diags = validateContentModel(xml);
             const cmErrors = diags.filter(d => d.code === 'DITA-CM-001');
             assert.strictEqual(cmErrors.length, 0);
+        });
+
+        test('section with <parml>, <screen>, <syntaxdiagram> is valid (regression)', () => {
+            const xml =
+                '<topic id="t1"><title>T</title><body><section><title>S</title>' +
+                '<parml><plentry><pt>x</pt><pd>y</pd></plentry></parml>' +
+                '<screen>code</screen>' +
+                '<syntaxdiagram>diagram</syntaxdiagram>' +
+                '</section></body></topic>';
+            const diags = validateContentModel(xml);
+            const cmErrors = diags.filter(d => d.code === 'DITA-CM-001' || d.code === 'DITA-CM-003');
+            assert.deepStrictEqual(cmErrors, []);
         });
     });
 

--- a/server/test/contextGraph.test.ts
+++ b/server/test/contextGraph.test.ts
@@ -4,6 +4,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import { URI } from 'vscode-uri';
 import { handleGetContextGraph } from '../src/features/contextGraph';
+import { IKeySpaceService } from '../src/services/interfaces';
 
 function makeTmpDir(): string {
     return fs.mkdtempSync(path.join(os.tmpdir(), 'ditacraft-ctxgraph-'));
@@ -43,6 +44,44 @@ suite('handleGetContextGraph', () => {
                 assert.strictEqual(graph.rootMap.children.length, 2, 'root should have 2 children');
             } finally {
                 cleanup(tmpDir);
+            }
+        });
+
+        test('topicref escaping the workspace is not resolved into a child', () => {
+            // root.ditamap (inside workspaceRoot/docs) references
+            // "../../outside.dita", which escapes workspaceRoot entirely. The
+            // file genuinely exists on disk, so without a workspace-boundary
+            // check resolveHref's ">8 levels" heuristic alone would not catch a
+            // shallow escape like this, and it would be resolved and read.
+            const workspaceRoot = makeTmpDir();
+            const docsDir = path.join(workspaceRoot, 'docs');
+            fs.mkdirSync(docsDir);
+            const outsideFile = path.join(os.tmpdir(), 'outside.dita');
+            fs.writeFileSync(outsideFile, '<topic id="o"><title>Outside</title></topic>', 'utf-8');
+
+            const mapPath = path.join(docsDir, 'root.ditamap');
+            fs.writeFileSync(mapPath, `<?xml version="1.0"?>
+<map title="My Map">
+  <topicref href="../../outside.dita"/>
+</map>`, 'utf-8');
+
+            const mockKeySpaceService = {
+                getWorkspaceFolders: () => [workspaceRoot],
+            } as unknown as IKeySpaceService;
+
+            try {
+                const graph = handleGetContextGraph({
+                    uri: URI.file(mapPath).toString(),
+                    depth: 2,
+                    includeMetadata: false,
+                }, mockKeySpaceService);
+
+                assert.strictEqual(graph.rootMap.children.length, 0,
+                    'escaping topicref should not be resolved into a child');
+                assert.strictEqual(graph.topics.length, 0, 'no topic outside the workspace should be indexed');
+            } finally {
+                cleanup(workspaceRoot);
+                fs.rmSync(outsideFile, { force: true });
             }
         });
 

--- a/server/test/crossRefValidation.test.ts
+++ b/server/test/crossRefValidation.test.ts
@@ -8,13 +8,14 @@ import { KeySpaceService, KeyDefinition } from '../src/services/keySpaceService'
 
 function createMockKeySpaceService(
     keys: Map<string, KeyDefinition>,
-    duplicateKeys?: Map<string, KeyDefinition[]>
+    duplicateKeys?: Map<string, KeyDefinition[]>,
+    workspaceFolders: readonly string[] = []
 ): KeySpaceService {
     return {
         getAllKeys: async () => keys,
         resolveKey: async (keyName: string) => keys.get(keyName) ?? null,
         getDuplicateKeys: async () => duplicateKeys ?? new Map(),
-        getWorkspaceFolders: () => [],
+        getWorkspaceFolders: () => workspaceFolders,
         buildKeySpace: async () => ({
             rootMap: '',
             keys,
@@ -62,6 +63,32 @@ suite('validateCrossReferences', () => {
                 assert.strictEqual(missing.length, 0);
             } finally {
                 fs.rmSync(tmpDir, { recursive: true, force: true });
+            }
+        });
+
+        test('href escaping the workspace is treated as missing, not read', async () => {
+            // workspaceRoot/docs/source.dita references "../../secret.dita", which
+            // escapes workspaceRoot entirely into a sibling directory. The file
+            // genuinely exists on disk, so without a workspace-boundary guard the
+            // validator would happily fs.access/read it. It must be reported as
+            // missing instead, and never actually read.
+            const workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ditacraft-ws-'));
+            const docsDir = path.join(workspaceRoot, 'docs');
+            fs.mkdirSync(docsDir);
+            const secretFile = path.join(os.tmpdir(), 'secret.dita');
+            fs.writeFileSync(secretFile, '<topic id="s"><title>Secret</title></topic>');
+
+            try {
+                const text = '<xref href="../../secret.dita">link</xref>';
+                const testUri = URI.file(path.join(docsDir, 'source.dita')).toString();
+                const keySpaceService = createMockKeySpaceService(new Map(), undefined, [workspaceRoot]);
+
+                const diags = await validateCrossReferences(text, testUri, keySpaceService, 100);
+                const missing = diags.filter(d => d.code === XREF_CODES.MISSING_FILE);
+                assert.strictEqual(missing.length, 1, 'href escaping the workspace should be reported as missing');
+            } finally {
+                fs.rmSync(workspaceRoot, { recursive: true, force: true });
+                fs.rmSync(secretFile, { force: true });
             }
         });
 

--- a/server/test/documentLinks.test.ts
+++ b/server/test/documentLinks.test.ts
@@ -54,6 +54,31 @@ suite('handleDocumentLinks', () => {
         }
     });
 
+    test('a document opened outside every workspace folder still links to its own siblings (regression)', async () => {
+        // The open document lives entirely outside workspaceRoot (e.g. a loose
+        // file opened via File > Open while a different project is the active
+        // workspace). A same-directory sibling reference must still resolve —
+        // there is no workspace boundary to enforce for a document that isn't
+        // part of the workspace to begin with.
+        const workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ditacraft-ws-'));
+        const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ditacraft-outside-'));
+
+        try {
+            const sourceUri = URI.file(path.join(outsideDir, 'loose.ditamap')).toString();
+            const content = '<map><topicref href="sibling.dita"/></map>';
+            const doc = createDoc(content, sourceUri);
+            const docs = createDocs(doc);
+            const keySpaceService = mockKeySpaceService([workspaceRoot]);
+
+            const links = await handleDocumentLinks({ textDocument: { uri: sourceUri } }, docs, keySpaceService);
+            assert.strictEqual(links.length, 1, 'sibling reference from an out-of-workspace document should resolve');
+            assert.ok(links[0].target?.endsWith('sibling.dita'));
+        } finally {
+            fs.rmSync(workspaceRoot, { recursive: true, force: true });
+            fs.rmSync(outsideDir, { recursive: true, force: true });
+        }
+    });
+
     test('document not found returns empty', async () => {
         const docs = createDocs();
         const links = await handleDocumentLinks(

--- a/server/test/documentLinks.test.ts
+++ b/server/test/documentLinks.test.ts
@@ -1,0 +1,80 @@
+import * as assert from 'assert';
+import * as path from 'path';
+import * as fs from 'fs';
+import * as os from 'os';
+import { URI } from 'vscode-uri';
+import { handleDocumentLinks } from '../src/features/documentLinks';
+import { KeySpaceService } from '../src/services/keySpaceService';
+import { createDoc, createDocs } from './helper';
+
+function mockKeySpaceService(workspaceFolders: readonly string[]): KeySpaceService {
+    return {
+        getWorkspaceFolders: () => workspaceFolders,
+    } as unknown as KeySpaceService;
+}
+
+suite('handleDocumentLinks', () => {
+    test('href on topicref resolves to a same-workspace target', async () => {
+        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ditacraft-test-'));
+        try {
+            const sourceUri = URI.file(path.join(tmpDir, 'root.ditamap')).toString();
+            const content = '<map><topicref href="topic.dita"/></map>';
+            const doc = createDoc(content, sourceUri);
+            const docs = createDocs(doc);
+            const keySpaceService = mockKeySpaceService([tmpDir]);
+
+            const links = await handleDocumentLinks({ textDocument: { uri: sourceUri } }, docs, keySpaceService);
+            assert.strictEqual(links.length, 1);
+            assert.ok(links[0].target?.endsWith('topic.dita'));
+        } finally {
+            fs.rmSync(tmpDir, { recursive: true, force: true });
+        }
+    });
+
+    test('href escaping the workspace produces no link (regression)', async () => {
+        // root.ditamap (inside workspaceRoot/docs) references "../../secret.dita",
+        // which escapes workspaceRoot entirely into a sibling directory. Without a
+        // workspace-boundary guard this would resolve into a clickable link
+        // pointing outside the workspace.
+        const workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ditacraft-ws-'));
+        const docsDir = path.join(workspaceRoot, 'docs');
+        fs.mkdirSync(docsDir);
+
+        try {
+            const sourceUri = URI.file(path.join(docsDir, 'root.ditamap')).toString();
+            const content = '<map><topicref href="../../secret.dita"/></map>';
+            const doc = createDoc(content, sourceUri);
+            const docs = createDocs(doc);
+            const keySpaceService = mockKeySpaceService([workspaceRoot]);
+
+            const links = await handleDocumentLinks({ textDocument: { uri: sourceUri } }, docs, keySpaceService);
+            assert.strictEqual(links.length, 0, 'escaping href must not produce a navigable link');
+        } finally {
+            fs.rmSync(workspaceRoot, { recursive: true, force: true });
+        }
+    });
+
+    test('document not found returns empty', async () => {
+        const docs = createDocs();
+        const links = await handleDocumentLinks(
+            { textDocument: { uri: 'file:///nonexistent.dita' } },
+            docs
+        );
+        assert.strictEqual(links.length, 0);
+    });
+
+    test('without a keySpaceService (single-file mode), links still resolve', async () => {
+        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ditacraft-test-'));
+        try {
+            const sourceUri = URI.file(path.join(tmpDir, 'root.ditamap')).toString();
+            const content = '<map><topicref href="topic.dita"/></map>';
+            const doc = createDoc(content, sourceUri);
+            const docs = createDocs(doc);
+
+            const links = await handleDocumentLinks({ textDocument: { uri: sourceUri } }, docs);
+            assert.strictEqual(links.length, 1);
+        } finally {
+            fs.rmSync(tmpDir, { recursive: true, force: true });
+        }
+    });
+});

--- a/server/test/folding.test.ts
+++ b/server/test/folding.test.ts
@@ -75,6 +75,35 @@ suite('computeFoldingRanges', () => {
         assert.ok(ranges.length >= 3); // topic, body, section
     });
 
+    test('mismatched closing tag resyncs through intervening unclosed ancestors (regression)', () => {
+        // <c> (line 2) is never properly closed — </b> (line 3) is a mismatch
+        // that must resync by closing both <b> and <c>. A later stray </c>
+        // (line 5, no corresponding <c> reopened) must then be ignored rather
+        // than incorrectly pairing with the abandoned <c> from line 2 — which
+        // would produce a bogus fold range overlapping the unrelated <d> block.
+        const text =
+            '<a>\n' +
+            '  <b>\n' +
+            '    <c>\n' +
+            '</b>\n' +
+            '<d>\n' +
+            '</c>\n' +
+            '</d>\n' +
+            '</a>';
+        const ranges = computeFoldingRanges(text);
+
+        const bogusRange = ranges.find(r => r.startLine === 2);
+        assert.strictEqual(bogusRange, undefined,
+            'stray </c> at line 5 must not pair with the long-abandoned <c> at line 2');
+
+        // <b> ([1,3], resynced by the mismatched </b>), <d> ([4,6]), and <a>
+        // ([0,7]) each produce a fold; the stray </c> produces none.
+        assert.strictEqual(ranges.length, 3);
+        assert.ok(ranges.some(r => r.startLine === 1 && r.endLine === 3), '<b> fold should be [1,3]');
+        assert.ok(ranges.some(r => r.startLine === 4 && r.endLine === 6), '<d> fold should be [4,6]');
+        assert.ok(ranges.some(r => r.startLine === 0 && r.endLine === 7), '<a> fold should be [0,7]');
+    });
+
     test('Windows line endings (CRLF)', () => {
         const text = '<topic>\r\n  <title>T</title>\r\n</topic>';
         const ranges = computeFoldingRanges(text);

--- a/server/test/fragmentValidator.test.ts
+++ b/server/test/fragmentValidator.test.ts
@@ -1,0 +1,120 @@
+import * as assert from 'assert';
+import { handleValidateFragment, ValidateFragmentParams } from '../src/features/fragmentValidator';
+import { ValidationPipeline } from '../src/services/validationPipeline';
+import { CatalogValidationService } from '../src/services/catalogValidationService';
+import { RngValidationService } from '../src/services/rngValidationService';
+import { SubjectSchemeService } from '../src/services/subjectSchemeService';
+import { initSettings, updateGlobalSettings, clearDocumentSettings } from '../src/settings';
+
+function makeCatalogService(): CatalogValidationService {
+    return {
+        isAvailable: false,
+        validate: () => [],
+        initialize: () => {},
+        reinitialize: () => {},
+        error: null,
+    } as unknown as CatalogValidationService;
+}
+
+function makeRngService(): RngValidationService {
+    return {
+        isAvailable: false,
+        validate: async () => [],
+        initialize: () => {},
+        setSchemaBasePath: () => {},
+        error: null,
+    } as unknown as RngValidationService;
+}
+
+function makeSubjectSchemeService(): SubjectSchemeService {
+    return {
+        hasSchemeData: () => false,
+        registerSchemes: () => {},
+        getValidValues: () => null,
+        isControlledAttribute: () => false,
+        invalidate: () => {},
+        shutdown: () => {},
+    } as unknown as SubjectSchemeService;
+}
+
+function makePipeline(): ValidationPipeline {
+    return new ValidationPipeline(makeCatalogService(), makeRngService(), makeSubjectSchemeService());
+}
+
+/** Configure the settings module so getDocumentSettings() resolves via a mock connection. */
+function useConnectionConfig(config: Record<string, unknown>): void {
+    const mockConnection = {
+        workspace: { getConfiguration: () => Promise.resolve(config) },
+    };
+    initSettings(mockConnection as never, true);
+    clearDocumentSettings();
+}
+
+suite('handleValidateFragment', () => {
+
+    teardown(() => {
+        clearDocumentSettings();
+        initSettings({
+            workspace: { getConfiguration: () => Promise.resolve({}) },
+        } as never, false);
+        updateGlobalSettings({});
+    });
+
+    suite('settings source (regression)', () => {
+        // A fragment that trips DITA-SCH-011 (deprecated @alt on <image>) whenever
+        // DITA rules validation is enabled — the default.
+        const params: ValidateFragmentParams = {
+            fragment: '<image href="pic.png" alt="description"/>',
+            contextUri: 'file:///workspace/topic.dita',
+            fragmentType: 'element',
+        };
+
+        test('honors the real per-document settings (rule fires when enabled)', async () => {
+            useConnectionConfig({}); // defaults — ditaRulesEnabled: true
+            const result = await handleValidateFragment(params, makePipeline());
+            const sch011 = result.diagnostics.filter(d => d.code === 'DITA-SCH-011');
+            assert.strictEqual(sch011.length, 1, 'rule should fire under default per-document settings');
+        });
+
+        test('honors the real per-document settings (rule silenced when disabled)', async () => {
+            // Per-document config (as the real client would report it) disables
+            // DITA rules entirely. Before the fix, handleValidateFragment read
+            // getGlobalSettings() instead — which stays hardcoded at defaults
+            // (ditaRulesEnabled: true) whenever the client supports configuration
+            // pull — so this diagnostic would incorrectly still appear.
+            useConnectionConfig({ ditaRulesEnabled: false });
+            const result = await handleValidateFragment(params, makePipeline());
+            const sch011 = result.diagnostics.filter(d => d.code === 'DITA-SCH-011');
+            assert.strictEqual(sch011.length, 0, 'rule must be silenced per the real per-document config');
+        });
+    });
+
+    suite('wrapFragment (regression)', () => {
+        test('map fragment with sibling topicrefs and no root wraps into a single well-formed document', async () => {
+            useConnectionConfig({});
+            const params: ValidateFragmentParams = {
+                fragment: '<topicref href="a.dita"/>\n<topicref href="b.dita"/>',
+                contextUri: 'file:///workspace/root.ditamap',
+                fragmentType: 'map',
+            };
+            const result = await handleValidateFragment(params, makePipeline());
+            const wellFormednessErrors = result.diagnostics.filter(d => d.code === 'DITA-XML-001');
+            assert.strictEqual(
+                wellFormednessErrors.length, 0,
+                'sibling topicrefs should be wrapped in a single <map> root, not reported as malformed XML'
+            );
+        });
+
+        test('map fragment already rooted in <map> is used as-is', async () => {
+            useConnectionConfig({});
+            const params: ValidateFragmentParams = {
+                fragment: '<map><topicref href="a.dita"/></map>',
+                contextUri: 'file:///workspace/root.ditamap',
+                fragmentType: 'map',
+            };
+            const result = await handleValidateFragment(params, makePipeline());
+            const wellFormednessErrors = result.diagnostics.filter(d => d.code === 'DITA-XML-001');
+            assert.strictEqual(wellFormednessErrors.length, 0);
+        });
+    });
+});

--- a/server/test/keySpaceService.test.ts
+++ b/server/test/keySpaceService.test.ts
@@ -343,6 +343,35 @@ suite('KeySpaceService', () => {
             }
         });
 
+        test('diamond-shaped mapref: same submap reached via two different keyscopes registers keys under both', async () => {
+            const tmpDir = makeTmpDir();
+            const service = createService(tmpDir);
+            try {
+                const rootPath = path.join(tmpDir, 'root.ditamap');
+                fs.writeFileSync(rootPath, `<?xml version="1.0"?>
+<map>
+  <mapref href="shared.ditamap" keyscope="prodA"/>
+  <mapref href="shared.ditamap" keyscope="prodB"/>
+</map>`, 'utf-8');
+
+                const sharedPath = path.join(tmpDir, 'shared.ditamap');
+                fs.writeFileSync(sharedPath, `<?xml version="1.0"?>
+<map>
+  <keydef keys="widget" href="widget.dita"/>
+</map>`, 'utf-8');
+
+                const keySpace = await service.buildKeySpace(rootPath);
+                assert.ok(keySpace.keys.has('widget'), 'unqualified key should exist');
+                assert.ok(keySpace.keys.has('prodA.widget'),
+                    'key should resolve under the first keyscope that reaches the shared submap');
+                assert.ok(keySpace.keys.has('prodB.widget'),
+                    'key should also resolve under the second keyscope reaching the same shared submap');
+            } finally {
+                service.shutdown();
+                cleanup(tmpDir);
+            }
+        });
+
         test('keyscope on submap root element is applied', async () => {
             const tmpDir = makeTmpDir();
             const service = createService(tmpDir);

--- a/server/test/keySpaceService.test.ts
+++ b/server/test/keySpaceService.test.ts
@@ -111,6 +111,41 @@ suite('KeySpaceService', () => {
                 cleanup(tmpDir);
             }
         });
+
+        test('cyclic map references (A -> B -> A) terminate instead of hanging (regression)', async () => {
+            // Guards the diamond-scope submap re-queueing fix: a genuine cycle
+            // back to an already-visited map+scope combination must be
+            // recognized as already-registered and skipped, not re-queued
+            // forever.
+            const tmpDir = makeTmpDir();
+            const service = createService(tmpDir);
+            try {
+                const mapAPath = path.join(tmpDir, 'a.ditamap');
+                const mapBPath = path.join(tmpDir, 'b.ditamap');
+                fs.writeFileSync(mapAPath, `<?xml version="1.0"?>
+<map>
+  <keydef keys="keyA" href="a.dita"/>
+  <mapref href="b.ditamap"/>
+</map>`, 'utf-8');
+                fs.writeFileSync(mapBPath, `<?xml version="1.0"?>
+<map>
+  <keydef keys="keyB" href="b.dita"/>
+  <mapref href="a.ditamap"/>
+</map>`, 'utf-8');
+
+                const buildPromise = service.buildKeySpace(mapAPath);
+                const timeout = new Promise((_, reject) =>
+                    setTimeout(() => reject(new Error('buildKeySpace did not terminate')), 5000)
+                );
+                const keySpace = await Promise.race([buildPromise, timeout]) as Awaited<typeof buildPromise>;
+
+                assert.ok(keySpace.keys.has('keyA'));
+                assert.ok(keySpace.keys.has('keyB'));
+            } finally {
+                service.shutdown();
+                cleanup(tmpDir);
+            }
+        });
     });
 
     suite('resolveKey', () => {
@@ -366,6 +401,48 @@ suite('KeySpaceService', () => {
                     'key should resolve under the first keyscope that reaches the shared submap');
                 assert.ok(keySpace.keys.has('prodB.widget'),
                     'key should also resolve under the second keyscope reaching the same shared submap');
+            } finally {
+                service.shutdown();
+                cleanup(tmpDir);
+            }
+        });
+
+        test('diamond-shaped mapref: nested submaps are re-queued and resolve under both scopes (regression)', async () => {
+            // shared.ditamap is reached via two different keyscopes, and itself
+            // references a nested child.ditamap. Before this fix, only
+            // shared.ditamap's own direct keys were re-registered on the second
+            // visit — child.ditamap's keys stayed unresolvable under the
+            // second scope even though child.ditamap is logically included
+            // under it too.
+            const tmpDir = makeTmpDir();
+            const service = createService(tmpDir);
+            try {
+                const rootPath = path.join(tmpDir, 'root.ditamap');
+                fs.writeFileSync(rootPath, `<?xml version="1.0"?>
+<map>
+  <mapref href="shared.ditamap" keyscope="prodA"/>
+  <mapref href="shared.ditamap" keyscope="prodB"/>
+</map>`, 'utf-8');
+
+                const sharedPath = path.join(tmpDir, 'shared.ditamap');
+                fs.writeFileSync(sharedPath, `<?xml version="1.0"?>
+<map>
+  <keydef keys="widget" href="widget.dita"/>
+  <mapref href="child.ditamap"/>
+</map>`, 'utf-8');
+
+                const childPath = path.join(tmpDir, 'child.ditamap');
+                fs.writeFileSync(childPath, `<?xml version="1.0"?>
+<map>
+  <keydef keys="gadget" href="gadget.dita"/>
+</map>`, 'utf-8');
+
+                const keySpace = await service.buildKeySpace(rootPath);
+                assert.ok(keySpace.keys.has('gadget'), 'unqualified nested key should exist');
+                assert.ok(keySpace.keys.has('prodA.gadget'),
+                    'nested submap key should resolve under the first keyscope');
+                assert.ok(keySpace.keys.has('prodB.gadget'),
+                    'nested submap key should also resolve under the second keyscope reaching it via the shared parent');
             } finally {
                 service.shutdown();
                 cleanup(tmpDir);

--- a/server/test/keySpaceService.test.ts
+++ b/server/test/keySpaceService.test.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
 import { KeySpaceService, formatResolutionReport, reportKeySpace } from '../src/services/keySpaceService';
+import { normalizeFsPath } from '../src/utils/textUtils';
 
 function makeTmpDir(): string {
     return fs.mkdtempSync(path.join(os.tmpdir(), 'ditacraft-test-'));
@@ -859,7 +860,7 @@ suite('KeySpaceService', () => {
                 fs.writeFileSync(guidePath, '', 'utf-8');
 
                 const keySpace = await service.buildKeySpace(rootPath);
-                const scopePrefix = keySpace.topicToScope.get(path.normalize(guidePath));
+                const scopePrefix = keySpace.topicToScope.get(normalizeFsPath(guidePath));
                 assert.strictEqual(scopePrefix, 'lib',
                     'lib-guide.dita should be recorded in the "lib" scope');
             } finally {
@@ -972,7 +973,7 @@ suite('KeySpaceService', () => {
                 const keySpace = await service.buildKeySpace(rootPath);
                 // guide.dita is referenced in the root reltable AND in child scope.
                 // The reltable reference (root scope) must NOT win — guide.dita belongs to child scope.
-                const scopePrefix = keySpace.topicToScope.get(path.normalize(guidePath));
+                const scopePrefix = keySpace.topicToScope.get(normalizeFsPath(guidePath));
                 assert.strictEqual(scopePrefix, 'child',
                     'reltable href must not claim scope — child scope topicref should win');
             } finally {
@@ -1124,7 +1125,7 @@ suite('KeySpaceService', () => {
                 fs.writeFileSync(guidePath, '', 'utf-8');
 
                 const keySpace = await service.buildKeySpace(mapPath);
-                const scopePrefix = keySpace.topicToScope.get(path.normalize(guidePath));
+                const scopePrefix = keySpace.topicToScope.get(normalizeFsPath(guidePath));
                 assert.strictEqual(scopePrefix, 'branch',
                     'topic inside inline scope branch should map to that scope');
             } finally {

--- a/server/test/keySpaceService.test.ts
+++ b/server/test/keySpaceService.test.ts
@@ -867,6 +867,56 @@ suite('KeySpaceService', () => {
                 cleanup(tmpDir);
             }
         });
+
+        test('resolveKey matches a case-differing context path on Windows (regression)', async () => {
+            // vscode-uri's URI.file() lowercases Windows drive letters on
+            // round-trip, so a context path derived from a document URI can
+            // differ in case from the same path as resolved via path.resolve()
+            // while walking the map. A bare path.normalize() does not fold
+            // case, so topicToScope lookups would silently miss on Windows.
+            const tmpDir = makeTmpDir();
+            const service = createService(tmpDir);
+            const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')!;
+            try {
+                const rootPath = path.join(tmpDir, 'root.ditamap');
+                fs.writeFileSync(rootPath, `<?xml version="1.0"?>
+<map>
+  <keydef keys="version" href="v1.dita"/>
+  <mapref href="product.ditamap" keyscope="product"/>
+</map>`, 'utf-8');
+
+                const subPath = path.join(tmpDir, 'product.ditamap');
+                fs.writeFileSync(subPath, `<?xml version="1.0"?>
+<map>
+  <keydef keys="version" href="v2.dita"/>
+  <topicref href="product-guide.dita"/>
+</map>`, 'utf-8');
+
+                const productGuide = path.join(tmpDir, 'product-guide.dita');
+                fs.writeFileSync(productGuide, '', 'utf-8');
+
+                Object.defineProperty(process, 'platform', { value: 'win32' });
+
+                // Only the filename segment differs in case — the directory
+                // must stay real so findRootMap's readdir still locates
+                // root.ditamap.
+                const mixedCaseGuide = path.join(
+                    path.dirname(productGuide),
+                    path.basename(productGuide).toUpperCase()
+                );
+
+                const result = await service.resolveKey('version', mixedCaseGuide);
+                assert.ok(result, 'resolveKey should resolve despite the case-differing context path');
+                assert.ok(
+                    result!.targetFile?.endsWith('v2.dita'),
+                    'context-aware resolution should still find the product-scope version (v2) on Windows'
+                );
+            } finally {
+                Object.defineProperty(process, 'platform', originalPlatform);
+                service.shutdown();
+                cleanup(tmpDir);
+            }
+        });
     });
 
     suite('reltable exclusion', () => {

--- a/server/test/references.test.ts
+++ b/server/test/references.test.ts
@@ -1,0 +1,128 @@
+import * as assert from 'assert';
+import * as path from 'path';
+import * as fs from 'fs';
+import * as os from 'os';
+import { URI } from 'vscode-uri';
+import { handleReferences } from '../src/features/references';
+import { KeySpaceService, KeyDefinition } from '../src/services/keySpaceService';
+import { createDoc, createDocs } from './helper';
+
+function mockKeySpaceService(resolve: (keyName: string, contextFilePath: string) => KeyDefinition | null): KeySpaceService {
+    return {
+        resolveKey: async (keyName: string, contextFilePath: string) => resolve(keyName, contextFilePath),
+    } as unknown as KeySpaceService;
+}
+
+suite('handleReferences', () => {
+    test('finds a same-file fragment-only reference', async () => {
+        const content = '<topic id="t1"><title>T</title><body><p><xref href="#t1"/></p></body></topic>';
+        const doc = createDoc(content);
+        const docs = createDocs(doc);
+
+        const idAttrOffset = content.indexOf('id="t1"');
+        const position = doc.positionAt(idAttrOffset + 4);
+
+        const results = await handleReferences(
+            { textDocument: { uri: doc.uri }, position, context: { includeDeclaration: false } },
+            docs
+        );
+        assert.strictEqual(results.length, 1);
+    });
+
+    test('includeDeclaration adds the element itself', async () => {
+        const content = '<topic id="t1"><title>T</title><body><p><xref href="#t1"/></p></body></topic>';
+        const doc = createDoc(content);
+        const docs = createDocs(doc);
+
+        const idAttrOffset = content.indexOf('id="t1"');
+        const position = doc.positionAt(idAttrOffset + 4);
+
+        const results = await handleReferences(
+            { textDocument: { uri: doc.uri }, position, context: { includeDeclaration: true } },
+            docs
+        );
+        assert.strictEqual(results.length, 2, 'declaration + the one xref reference');
+    });
+
+    test('same-file href pointing to a different file with a matching id is excluded (regression)', async () => {
+        // The id "s1" being searched lives in this document, but the xref
+        // below points to "other.dita#topic/s1" — a *different* file whose
+        // element merely happens to share the same id text. It must not be
+        // reported as a reference.
+        const content =
+            '<topic id="root"><title>T</title><body>' +
+            '<step id="s1"/>' +
+            '<xref href="other.dita#topic/s1"/>' +
+            '</body></topic>';
+        const doc = createDoc(content, URI.file('/workspace/this.dita').toString());
+        const docs = createDocs(doc);
+
+        const idAttrOffset = content.indexOf('id="s1"');
+        const position = doc.positionAt(idAttrOffset + 4);
+
+        const results = await handleReferences(
+            { textDocument: { uri: doc.uri }, position, context: { includeDeclaration: false } },
+            docs
+        );
+        assert.strictEqual(results.length, 0, 'href pointing at a different file must not be reported');
+    });
+
+    test('cross-file conkeyref resolving to the target file is included, resolving elsewhere is excluded (regression)', async () => {
+        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ditacraft-test-'));
+        try {
+            const targetPath = path.join(tmpDir, 'target.dita');
+            const unrelatedPath = path.join(tmpDir, 'unrelated.dita');
+            const goodRefPath = path.join(tmpDir, 'good-ref.dita');
+            const badRefPath = path.join(tmpDir, 'bad-ref.dita');
+
+            fs.writeFileSync(targetPath, '<topic id="t1"><title>T</title></topic>');
+            fs.writeFileSync(unrelatedPath, '<topic id="t1"><title>U</title></topic>');
+            fs.writeFileSync(goodRefPath,
+                '<topic id="g1"><title>G</title><body><p conkeyref="goodkey/t1">x</p></body></topic>');
+            fs.writeFileSync(badRefPath,
+                '<topic id="b1"><title>B</title><body><p conkeyref="badkey/t1">x</p></body></topic>');
+
+            const doc = createDoc(fs.readFileSync(targetPath, 'utf-8'), URI.file(targetPath).toString());
+            const docs = createDocs(doc);
+
+            const keySpaceService = mockKeySpaceService((keyName) => {
+                if (keyName === 'goodkey') return { keyName, targetFile: targetPath, sourceMap: targetPath };
+                if (keyName === 'badkey') return { keyName, targetFile: unrelatedPath, sourceMap: unrelatedPath };
+                return null;
+            });
+
+            const results = await handleReferences(
+                { textDocument: { uri: doc.uri }, position: { line: 0, character: 12 }, context: { includeDeclaration: false } },
+                docs,
+                [tmpDir],
+                keySpaceService
+            );
+
+            const goodUri = URI.file(goodRefPath).toString();
+            const badUri = URI.file(badRefPath).toString();
+            assert.ok(results.some(r => r.uri === goodUri), 'conkeyref resolving to the target file should be found');
+            assert.ok(!results.some(r => r.uri === badUri), 'conkeyref resolving elsewhere must be excluded');
+        } finally {
+            fs.rmSync(tmpDir, { recursive: true, force: true });
+        }
+    });
+
+    test('cursor not on an id attribute returns empty', async () => {
+        const doc = createDoc('<topic id="t1"><title>T</title></topic>');
+        const docs = createDocs(doc);
+        const results = await handleReferences(
+            { textDocument: { uri: doc.uri }, position: { line: 0, character: 0 }, context: { includeDeclaration: false } },
+            docs
+        );
+        assert.strictEqual(results.length, 0);
+    });
+
+    test('document not found returns empty', async () => {
+        const docs = createDocs();
+        const results = await handleReferences(
+            { textDocument: { uri: 'file:///nonexistent.dita' }, position: { line: 0, character: 0 }, context: { includeDeclaration: false } },
+            docs
+        );
+        assert.strictEqual(results.length, 0);
+    });
+});

--- a/server/test/references.test.ts
+++ b/server/test/references.test.ts
@@ -107,6 +107,41 @@ suite('handleReferences', () => {
         }
     });
 
+    test('skipping an unverifiable conkeyref without a KeySpaceService is logged (regression)', async () => {
+        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ditacraft-test-'));
+        try {
+            const targetPath = path.join(tmpDir, 'target.dita');
+            const referencerPath = path.join(tmpDir, 'referencer.dita');
+
+            fs.writeFileSync(targetPath, '<topic id="t1"><title>T</title></topic>');
+            fs.writeFileSync(referencerPath,
+                '<topic id="r1"><title>R</title><body><p conkeyref="mykey/t1">x</p></body></topic>');
+
+            const doc = createDoc(fs.readFileSync(targetPath, 'utf-8'), URI.file(targetPath).toString());
+            const docs = createDocs(doc);
+
+            const logs: string[] = [];
+            const results = await handleReferences(
+                { textDocument: { uri: doc.uri }, position: { line: 0, character: 12 }, context: { includeDeclaration: false } },
+                docs,
+                [tmpDir],
+                // no keySpaceService
+                undefined,
+                (msg) => logs.push(msg)
+            );
+
+            const referencerUri = URI.file(referencerPath).toString();
+            assert.ok(!results.some(r => r.uri === referencerUri),
+                'without a KeySpaceService, an unverifiable conkeyref must not be reported as a match');
+            assert.ok(
+                logs.some(m => m.includes('mykey/t1')),
+                'skipping an unverifiable conkeyref should be logged so it is not silently dropped'
+            );
+        } finally {
+            fs.rmSync(tmpDir, { recursive: true, force: true });
+        }
+    });
+
     test('cursor not on an id attribute returns empty', async () => {
         const doc = createDoc('<topic id="t1"><title>T</title></topic>');
         const docs = createDocs(doc);

--- a/server/test/rename.test.ts
+++ b/server/test/rename.test.ts
@@ -196,16 +196,23 @@ suite('handleRename', () => {
             const doc = createDoc(fs.readFileSync(targetPath, 'utf-8'), URI.file(targetPath).toString());
             const docs = createDocs(doc);
 
+            const logs: string[] = [];
             const edit = await handleRename(
                 { textDocument: { uri: doc.uri }, position: { line: 0, character: 12 }, newName: 't1new' },
                 docs,
-                [tmpDir]
+                [tmpDir],
                 // no keySpaceService
+                undefined,
+                (msg) => logs.push(msg)
             );
 
             const referencerUri = URI.file(referencerPath).toString();
             assert.ok(!edit?.changes?.[referencerUri],
                 'without a KeySpaceService, an unverifiable conkeyref must not be rewritten');
+            assert.ok(
+                logs.some(m => m.includes('mykey/t1')),
+                'skipping an unverifiable conkeyref should be logged so it is not silently dropped (regression)'
+            );
         } finally {
             fs.rmSync(tmpDir, { recursive: true, force: true });
         }

--- a/server/test/rename.test.ts
+++ b/server/test/rename.test.ts
@@ -1,0 +1,223 @@
+import * as assert from 'assert';
+import * as path from 'path';
+import * as fs from 'fs';
+import * as os from 'os';
+import { URI } from 'vscode-uri';
+import { handlePrepareRename, handleRename } from '../src/features/rename';
+import { KeySpaceService, KeyDefinition } from '../src/services/keySpaceService';
+import { createDoc, createDocs } from './helper';
+
+function mockKeySpaceService(resolve: (keyName: string, contextFilePath: string) => KeyDefinition | null): KeySpaceService {
+    return {
+        resolveKey: async (keyName: string, contextFilePath: string) => resolve(keyName, contextFilePath),
+    } as unknown as KeySpaceService;
+}
+
+suite('handlePrepareRename', () => {
+    test('cursor on id attribute value returns its range', () => {
+        const doc = createDoc('<topic id="t1"><title>T</title></topic>');
+        const docs = createDocs(doc);
+        const range = handlePrepareRename(
+            { textDocument: { uri: doc.uri }, position: { line: 0, character: 12 } },
+            docs
+        );
+        assert.ok(range, 'should return a range on the id value');
+    });
+
+    test('cursor elsewhere returns null', () => {
+        const doc = createDoc('<topic id="t1"><title>T</title></topic>');
+        const docs = createDocs(doc);
+        const range = handlePrepareRename(
+            { textDocument: { uri: doc.uri }, position: { line: 0, character: 0 } },
+            docs
+        );
+        assert.strictEqual(range, null);
+    });
+});
+
+suite('handleRename', () => {
+    test('renames the id attribute and a same-file fragment-only reference', async () => {
+        const content = '<topic id="t1"><title>T</title><body><p><xref href="#t1"/></p></body></topic>';
+        const doc = createDoc(content);
+        const docs = createDocs(doc);
+
+        const edit = await handleRename(
+            { textDocument: { uri: doc.uri }, position: { line: 0, character: 12 }, newName: 't1new' },
+            docs
+        );
+
+        assert.ok(edit?.changes);
+        const edits = edit!.changes![doc.uri];
+        assert.strictEqual(edits.length, 2, 'should rewrite both the id and the #t1 fragment ref');
+        assert.ok(edits.some(e => e.newText === 't1new'));
+        assert.ok(edits.some(e => e.newText === '#t1new'));
+    });
+
+    test('same-file href pointing to a different file with a matching id is NOT rewritten (regression)', async () => {
+        // The renamed id "s1" lives in this document, but the xref below points
+        // to "other.dita#topic/s1" — a *different* file whose element merely
+        // happens to share the same id text. It must be left untouched.
+        const content =
+            '<topic id="root"><title>T</title><body>' +
+            '<step id="s1"/>' +
+            '<xref href="other.dita#topic/s1"/>' +
+            '</body></topic>';
+        const doc = createDoc(content, URI.file('/workspace/this.dita').toString());
+        const docs = createDocs(doc);
+
+        const idAttrOffset = content.indexOf('id="s1"');
+        const offset = doc.positionAt(idAttrOffset + 4); // inside the "s1" value
+
+        const edit = await handleRename(
+            { textDocument: { uri: doc.uri }, position: offset, newName: 's1new' },
+            docs
+        );
+
+        assert.ok(edit?.changes);
+        const edits = edit!.changes![doc.uri];
+        assert.strictEqual(edits.length, 1, 'only the id attribute itself should be rewritten');
+        assert.strictEqual(edits[0].newText, 's1new');
+    });
+
+    test('cross-file href pointing to the renamed file is rewritten, href to another file is not', async () => {
+        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ditacraft-test-'));
+        try {
+            const targetPath = path.join(tmpDir, 'target.dita');
+            const otherPath = path.join(tmpDir, 'other.dita');
+            const elsewherePath = path.join(tmpDir, 'elsewhere.dita');
+
+            fs.writeFileSync(targetPath, '<topic id="t1"><title>T</title></topic>');
+            fs.writeFileSync(otherPath, '<topic id="o1"><title>O</title><body><xref href="target.dita#t1"/></body></topic>');
+            fs.writeFileSync(elsewherePath, '<topic id="e1"><title>E</title><body><xref href="somewhere-else.dita#t1"/></body></topic>');
+
+            const doc = createDoc(fs.readFileSync(targetPath, 'utf-8'), URI.file(targetPath).toString());
+            const docs = createDocs(doc);
+
+            const edit = await handleRename(
+                { textDocument: { uri: doc.uri }, position: { line: 0, character: 12 }, newName: 't1new' },
+                docs,
+                [tmpDir]
+            );
+
+            const otherUri = URI.file(otherPath).toString();
+            const elsewhereUri = URI.file(elsewherePath).toString();
+            assert.ok(edit?.changes?.[otherUri], 'other.dita references target.dita and should be rewritten');
+            assert.ok(!edit?.changes?.[elsewhereUri], 'elsewhere.dita points at a different file and must be untouched');
+        } finally {
+            fs.rmSync(tmpDir, { recursive: true, force: true });
+        }
+    });
+
+    test('cross-file conkeyref resolving to the renamed file is rewritten (regression)', async () => {
+        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ditacraft-test-'));
+        try {
+            const targetPath = path.join(tmpDir, 'target.dita');
+            const referencerPath = path.join(tmpDir, 'referencer.dita');
+
+            fs.writeFileSync(targetPath, '<topic id="t1"><title>T</title></topic>');
+            fs.writeFileSync(referencerPath,
+                '<topic id="r1"><title>R</title><body><p conkeyref="mykey/t1">x</p></body></topic>');
+
+            const doc = createDoc(fs.readFileSync(targetPath, 'utf-8'), URI.file(targetPath).toString());
+            const docs = createDocs(doc);
+
+            const keySpaceService = mockKeySpaceService((keyName) =>
+                keyName === 'mykey'
+                    ? { keyName: 'mykey', targetFile: targetPath, sourceMap: targetPath }
+                    : null
+            );
+
+            const edit = await handleRename(
+                { textDocument: { uri: doc.uri }, position: { line: 0, character: 12 }, newName: 't1new' },
+                docs,
+                [tmpDir],
+                keySpaceService
+            );
+
+            const referencerUri = URI.file(referencerPath).toString();
+            assert.ok(edit?.changes?.[referencerUri], 'conkeyref resolving to the renamed file should be rewritten');
+            assert.strictEqual(edit!.changes![referencerUri][0].newText, 'mykey/t1new');
+        } finally {
+            fs.rmSync(tmpDir, { recursive: true, force: true });
+        }
+    });
+
+    test('cross-file conkeyref resolving to a DIFFERENT file is NOT rewritten (regression)', async () => {
+        // "mykey" resolves to some unrelated file, not the one being renamed —
+        // even though the conkeyref's trailing element id text ("s1") happens
+        // to match the id being renamed. Before the fix, this was rewritten
+        // unconditionally ("conkeyref: include all matches by element ID"),
+        // corrupting an unrelated file.
+        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ditacraft-test-'));
+        try {
+            const targetPath = path.join(tmpDir, 'target.dita');
+            const unrelatedPath = path.join(tmpDir, 'unrelated.dita');
+            const referencerPath = path.join(tmpDir, 'referencer.dita');
+
+            fs.writeFileSync(targetPath, '<topic id="s1"><title>T</title></topic>');
+            fs.writeFileSync(unrelatedPath, '<topic id="u1"><title>U</title><step id="s1"/></topic>');
+            fs.writeFileSync(referencerPath,
+                '<topic id="r1"><title>R</title><body><p conkeyref="otherkey/s1">x</p></body></topic>');
+
+            const doc = createDoc(fs.readFileSync(targetPath, 'utf-8'), URI.file(targetPath).toString());
+            const docs = createDocs(doc);
+
+            const keySpaceService = mockKeySpaceService((keyName) =>
+                keyName === 'otherkey'
+                    ? { keyName: 'otherkey', targetFile: unrelatedPath, sourceMap: unrelatedPath }
+                    : null
+            );
+
+            const edit = await handleRename(
+                { textDocument: { uri: doc.uri }, position: { line: 0, character: 12 }, newName: 's1new' },
+                docs,
+                [tmpDir],
+                keySpaceService
+            );
+
+            const referencerUri = URI.file(referencerPath).toString();
+            assert.ok(!edit?.changes?.[referencerUri],
+                'conkeyref resolving to an unrelated file must not be rewritten');
+        } finally {
+            fs.rmSync(tmpDir, { recursive: true, force: true });
+        }
+    });
+
+    test('conkeyref is skipped (not rewritten) when no KeySpaceService is available', async () => {
+        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ditacraft-test-'));
+        try {
+            const targetPath = path.join(tmpDir, 'target.dita');
+            const referencerPath = path.join(tmpDir, 'referencer.dita');
+
+            fs.writeFileSync(targetPath, '<topic id="t1"><title>T</title></topic>');
+            fs.writeFileSync(referencerPath,
+                '<topic id="r1"><title>R</title><body><p conkeyref="mykey/t1">x</p></body></topic>');
+
+            const doc = createDoc(fs.readFileSync(targetPath, 'utf-8'), URI.file(targetPath).toString());
+            const docs = createDocs(doc);
+
+            const edit = await handleRename(
+                { textDocument: { uri: doc.uri }, position: { line: 0, character: 12 }, newName: 't1new' },
+                docs,
+                [tmpDir]
+                // no keySpaceService
+            );
+
+            const referencerUri = URI.file(referencerPath).toString();
+            assert.ok(!edit?.changes?.[referencerUri],
+                'without a KeySpaceService, an unverifiable conkeyref must not be rewritten');
+        } finally {
+            fs.rmSync(tmpDir, { recursive: true, force: true });
+        }
+    });
+
+    test('cursor not on an id attribute returns null', async () => {
+        const doc = createDoc('<topic id="t1"><title>T</title></topic>');
+        const docs = createDocs(doc);
+        const edit = await handleRename(
+            { textDocument: { uri: doc.uri }, position: { line: 0, character: 0 }, newName: 'x' },
+            docs
+        );
+        assert.strictEqual(edit, null);
+    });
+});

--- a/server/test/rename.test.ts
+++ b/server/test/rename.test.ts
@@ -142,6 +142,51 @@ suite('handleRename', () => {
         }
     });
 
+    test('multiple conkeyrefs in one file resolve concurrently without mismatching edit-to-ref (regression)', async () => {
+        // Regression for parallelizing resolveKey calls: each ref's match
+        // result must still map to that same ref's own text edit, not get
+        // shuffled by concurrent resolution order.
+        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ditacraft-test-'));
+        try {
+            const targetPath = path.join(tmpDir, 'target.dita');
+            const unrelatedPath = path.join(tmpDir, 'unrelated.dita');
+            fs.writeFileSync(targetPath, '<topic id="t1"><title>T</title></topic>');
+            fs.writeFileSync(unrelatedPath, '<topic id="t1"><title>U</title></topic>');
+
+            const referencerPath = path.join(tmpDir, 'referencer.dita');
+            fs.writeFileSync(referencerPath,
+                '<topic id="r1"><title>R</title><body>' +
+                '<p conkeyref="badkey1/t1">a</p>' +
+                '<p conkeyref="goodkey/t1">b</p>' +
+                '<p conkeyref="badkey2/t1">c</p>' +
+                '</body></topic>');
+
+            const doc = createDoc(fs.readFileSync(targetPath, 'utf-8'), URI.file(targetPath).toString());
+            const docs = createDocs(doc);
+
+            const keySpaceService = mockKeySpaceService((keyName) =>
+                keyName === 'goodkey'
+                    ? { keyName: 'goodkey', targetFile: targetPath, sourceMap: targetPath }
+                    : { keyName, targetFile: unrelatedPath, sourceMap: unrelatedPath }
+            );
+
+            const edit = await handleRename(
+                { textDocument: { uri: doc.uri }, position: { line: 0, character: 12 }, newName: 't1new' },
+                docs,
+                [tmpDir],
+                keySpaceService
+            );
+
+            const referencerUri = URI.file(referencerPath).toString();
+            const edits = edit?.changes?.[referencerUri];
+            assert.ok(edits, 'referencer file should have an edit');
+            assert.strictEqual(edits!.length, 1, 'only the goodkey conkeyref should be rewritten');
+            assert.strictEqual(edits![0].newText, 'goodkey/t1new');
+        } finally {
+            fs.rmSync(tmpDir, { recursive: true, force: true });
+        }
+    });
+
     test('cross-file conkeyref resolving to a DIFFERENT file is NOT rewritten (regression)', async () => {
         // "mykey" resolves to some unrelated file, not the one being renamed —
         // even though the conkeyref's trailing element id text ("s1") happens

--- a/server/test/settings.test.ts
+++ b/server/test/settings.test.ts
@@ -205,4 +205,40 @@ suite('settings', () => {
             updateGlobalSettings({});
         });
     });
+
+    // ── getDocumentSettings recovers from a transient failure (regression) ──
+
+    suite('getDocumentSettings (transient connection failure)', () => {
+        test('a rejected getConfiguration call does not permanently poison the cache', async () => {
+            let callCount = 0;
+            const mockConnection = {
+                workspace: {
+                    getConfiguration: () => {
+                        callCount++;
+                        return callCount === 1
+                            ? Promise.reject(new Error('transient failure'))
+                            : Promise.resolve({ maxNumberOfProblems: 99 });
+                    },
+                },
+            };
+            initSettings(mockConnection as never, true);
+            clearDocumentSettings();
+
+            // First call fails — must resolve to defaults instead of rejecting,
+            // and must NOT leave a permanently-rejected promise cached.
+            const first = await getDocumentSettings('file:///flaky.dita');
+            assert.strictEqual(first.autoValidate, true, 'falls back to defaults on failure');
+
+            // Second call must retry (not reuse a cached rejection) and succeed.
+            const second = await getDocumentSettings('file:///flaky.dita');
+            assert.strictEqual(second.maxNumberOfProblems, 99, 'should retry and get the real config');
+
+            assert.strictEqual(callCount, 2, 'the failed call must not be cached — a retry should occur');
+
+            initSettings({
+                workspace: { getConfiguration: () => Promise.resolve({}) },
+            } as never, false);
+            updateGlobalSettings({});
+        });
+    });
 });

--- a/server/test/symbols.test.ts
+++ b/server/test/symbols.test.ts
@@ -109,6 +109,30 @@ suite('handleDocumentSymbol', () => {
         });
     });
 
+    suite('Mismatched closing tags (regression)', () => {
+        test('stray closing tag closes intervening unclosed ancestors too', () => {
+            // <section> is never explicitly closed; </body> is a mismatch that
+            // should resync by closing both <section> and <body>. The <table>
+            // that follows must land as a direct child of <topic>, not get
+            // nested inside the stuck-open <section>.
+            const content =
+                '<topic id="t1"><title>T</title>' +
+                '<body><section><title>Sec</title></body>' +
+                '<table><title>Tbl</title></table></topic>';
+            const result = symbols(content);
+            const topic = result[0];
+            assert.ok(topic.children, 'topic should have children');
+
+            const body = topic.children!.find(c => c.name.startsWith('body'));
+            assert.ok(body, 'body should be a child of topic');
+            const section = body!.children?.find(c => c.name.includes('Sec'));
+            assert.ok(section, 'section should be nested inside body');
+
+            const table = topic.children!.find(c => c.name.includes('Tbl'));
+            assert.ok(table, 'table must be a direct child of topic, not nested inside the stuck section');
+        });
+    });
+
     suite('Edge cases', () => {
         test('empty document returns empty', () => {
             const result = symbols('');
@@ -213,5 +237,22 @@ suite('handleWorkspaceSymbol', () => {
         );
         assert.ok(results.some(s => s.name.includes('In Memory')),
             'should find in-memory content');
+    });
+
+    test('mismatched closing tag does not corrupt containerName of later symbols (regression)', () => {
+        // <section> is never explicitly closed; </body> is a mismatch that
+        // should resync by closing both <section> and <body>, so <table>
+        // (which follows) must get containerName "Root" (the topic), not the
+        // stuck-open <section>'s name "Sec".
+        fs.writeFileSync(path.join(tmpDir, 'mismatch.dita'),
+            '<topic id="t1"><title>Root</title>' +
+            '<body><section><title>Sec</title></body>' +
+            '<table><title>Tbl</title></table></topic>');
+
+        const results = wsSymbols('Tbl');
+        const table = results.find(s => s.name.includes('Tbl'));
+        assert.ok(table, 'should find the table symbol');
+        assert.strictEqual(table!.containerName, 'Root',
+            'table should be attributed to topic ("Root"), not stuck inside section ("Sec")');
     });
 });

--- a/server/test/tagStack.test.ts
+++ b/server/test/tagStack.test.ts
@@ -1,0 +1,58 @@
+import * as assert from 'assert';
+import { resyncStackToMatch } from '../src/utils/tagStack';
+
+interface Entry {
+    name: string;
+}
+
+suite('resyncStackToMatch', () => {
+    test('matches the topmost entry and truncates through it', () => {
+        const stack: Entry[] = [{ name: 'a' }, { name: 'b' }, { name: 'c' }];
+        const matchIdx = resyncStackToMatch(stack, 'c', e => e.name);
+        assert.strictEqual(matchIdx, 2);
+        assert.deepStrictEqual(stack, [{ name: 'a' }, { name: 'b' }]);
+    });
+
+    test('matches an entry deeper in the stack and discards intervening entries', () => {
+        const stack: Entry[] = [{ name: 'a' }, { name: 'b' }, { name: 'c' }, { name: 'd' }];
+        const matchIdx = resyncStackToMatch(stack, 'b', e => e.name);
+        assert.strictEqual(matchIdx, 1);
+        assert.deepStrictEqual(stack, [{ name: 'a' }], 'stack must be truncated through and including the match');
+    });
+
+    test('returns -1 and leaves the stack untouched when nothing matches', () => {
+        const stack: Entry[] = [{ name: 'a' }, { name: 'b' }];
+        const matchIdx = resyncStackToMatch(stack, 'z', e => e.name);
+        assert.strictEqual(matchIdx, -1);
+        assert.deepStrictEqual(stack, [{ name: 'a' }, { name: 'b' }]);
+    });
+
+    test('invokes onDiscard for every discarded entry from top down, flagging only the match', () => {
+        const stack: Entry[] = [{ name: 'a' }, { name: 'b' }, { name: 'c' }, { name: 'd' }];
+        const calls: { name: string; index: number; isMatch: boolean }[] = [];
+
+        resyncStackToMatch(stack, 'b', e => e.name, (entry, index, isMatch) => {
+            calls.push({ name: entry.name, index, isMatch });
+        });
+
+        assert.deepStrictEqual(calls, [
+            { name: 'd', index: 3, isMatch: false },
+            { name: 'c', index: 2, isMatch: false },
+            { name: 'b', index: 1, isMatch: true },
+        ]);
+    });
+
+    test('does not invoke onDiscard when nothing matches', () => {
+        const stack: Entry[] = [{ name: 'a' }];
+        let called = false;
+        resyncStackToMatch(stack, 'z', e => e.name, () => { called = true; });
+        assert.strictEqual(called, false);
+    });
+
+    test('works with a plain string[] stack via the identity name accessor', () => {
+        const stack: string[] = ['a', 'b', 'c'];
+        const matchIdx = resyncStackToMatch(stack, 'a', name => name);
+        assert.strictEqual(matchIdx, 0);
+        assert.deepStrictEqual(stack, []);
+    });
+});

--- a/server/test/textUtils.test.ts
+++ b/server/test/textUtils.test.ts
@@ -1,10 +1,24 @@
 import * as assert from 'assert';
+import * as path from 'path';
 import {
     stripCommentsAndCDATA,
     stripCommentsAndCodeContent,
     offsetToRange,
     escapeRegex,
+    isPathWithinWorkspace,
+    normalizeFsPath,
 } from '../src/utils/textUtils';
+
+/** Temporarily override process.platform for a single test. */
+function withPlatform(platform: NodeJS.Platform, fn: () => void): void {
+    const original = Object.getOwnPropertyDescriptor(process, 'platform')!;
+    Object.defineProperty(process, 'platform', { value: platform });
+    try {
+        fn();
+    } finally {
+        Object.defineProperty(process, 'platform', original);
+    }
+}
 
 suite('textUtils', () => {
 
@@ -282,6 +296,73 @@ suite('textUtils', () => {
             const input = 'price: $1.99 (sale)';
             const pattern = new RegExp(escapeRegex(input));
             assert.ok(pattern.test(input));
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    suite('normalizeFsPath', () => {
+        test('is case-insensitive when platform is win32', () => {
+            withPlatform('win32', () => {
+                const a = normalizeFsPath('/Workspace/Topic.dita');
+                const b = normalizeFsPath('/workspace/topic.dita');
+                assert.strictEqual(a, b);
+            });
+        });
+
+        test('is case-sensitive on non-Windows platforms', () => {
+            withPlatform('linux', () => {
+                const a = normalizeFsPath('/Workspace/Topic.dita');
+                const b = normalizeFsPath('/workspace/topic.dita');
+                assert.notStrictEqual(a, b);
+            });
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    suite('isPathWithinWorkspace', () => {
+        test('empty workspaceFolders means single-file mode (always true)', () => {
+            assert.strictEqual(isPathWithinWorkspace('/any/path.dita', []), true);
+        });
+
+        test('path inside a workspace folder is within it', () => {
+            const workspaceFolders = [path.resolve('/workspace/project')];
+            const targetPath = path.resolve('/workspace/project/topics/topic.dita');
+            assert.strictEqual(isPathWithinWorkspace(targetPath, workspaceFolders), true);
+        });
+
+        test('path escaping the workspace folder is not within it', () => {
+            const workspaceFolders = [path.resolve('/workspace/project')];
+            const targetPath = path.resolve('/workspace/other/topic.dita');
+            assert.strictEqual(isPathWithinWorkspace(targetPath, workspaceFolders), false);
+        });
+
+        test('a sibling folder with a matching name prefix is not within it', () => {
+            // "/workspace/project-other" must not be considered inside
+            // "/workspace/project" just because the string starts with it.
+            const workspaceFolders = [path.resolve('/workspace/project')];
+            const targetPath = path.resolve('/workspace/project-other/topic.dita');
+            assert.strictEqual(isPathWithinWorkspace(targetPath, workspaceFolders), false);
+        });
+
+        test('matches despite case differences on win32 (regression)', () => {
+            // Reproduces the real Windows CI failure: vscode-uri's URI.file()
+            // lowercases the drive letter (and Windows paths are inherently
+            // case-insensitive), so a path derived via a file:// URI round-trip
+            // can differ in case from a workspace folder path taken as-is —
+            // they must still compare equal on win32.
+            withPlatform('win32', () => {
+                const workspaceFolders = ['/Workspace/Project'];
+                const targetPath = '/workspace/project/topic.dita';
+                assert.strictEqual(isPathWithinWorkspace(targetPath, workspaceFolders), true);
+            });
+        });
+
+        test('is case-sensitive on non-Windows platforms', () => {
+            withPlatform('linux', () => {
+                const workspaceFolders = ['/Workspace/Project'];
+                const targetPath = '/workspace/project/topic.dita';
+                assert.strictEqual(isPathWithinWorkspace(targetPath, workspaceFolders), false);
+            });
         });
     });
 });

--- a/server/test/textUtils.test.ts
+++ b/server/test/textUtils.test.ts
@@ -7,6 +7,7 @@ import {
     escapeRegex,
     isPathWithinWorkspace,
     normalizeFsPath,
+    effectiveWorkspaceFolders,
 } from '../src/utils/textUtils';
 
 /** Temporarily override process.platform for a single test. */
@@ -363,6 +364,40 @@ suite('textUtils', () => {
                 const targetPath = '/workspace/project/topic.dita';
                 assert.strictEqual(isPathWithinWorkspace(targetPath, workspaceFolders), false);
             });
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    suite('effectiveWorkspaceFolders', () => {
+        test('empty workspaceFolders is returned unchanged', () => {
+            const result = effectiveWorkspaceFolders('/any/document.dita', []);
+            assert.deepStrictEqual(result, []);
+        });
+
+        test('document inside a workspace folder keeps the real folder list', () => {
+            const workspaceFolders = [path.resolve('/workspace/project')];
+            const documentPath = path.resolve('/workspace/project/topic.dita');
+            assert.deepStrictEqual(effectiveWorkspaceFolders(documentPath, workspaceFolders), workspaceFolders);
+        });
+
+        test('document outside every workspace folder falls back to single-file mode (regression)', () => {
+            // A loose file opened outside any configured workspace folder must
+            // not have its own relative references blocked — otherwise even a
+            // trivial same-directory sibling reference would be treated as
+            // "outside the workspace" just because the document itself is.
+            const workspaceFolders = [path.resolve('/workspace/project')];
+            const documentPath = path.resolve('/elsewhere/loose-file.dita');
+            assert.deepStrictEqual(effectiveWorkspaceFolders(documentPath, workspaceFolders), []);
+        });
+
+        test('a reference from an out-of-workspace document then passes isPathWithinWorkspace (regression)', () => {
+            const workspaceFolders = [path.resolve('/workspace/project')];
+            const documentPath = path.resolve('/elsewhere/loose-file.dita');
+            const siblingTarget = path.resolve('/elsewhere/sibling.dita');
+
+            const effective = effectiveWorkspaceFolders(documentPath, workspaceFolders);
+            assert.strictEqual(isPathWithinWorkspace(siblingTarget, effective), true,
+                'a same-directory sibling of an out-of-workspace document must still resolve');
         });
     });
 });

--- a/server/test/workspaceScanner.test.ts
+++ b/server/test/workspaceScanner.test.ts
@@ -3,8 +3,9 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { URI } from 'vscode-uri';
-import { collectDitaFiles, findCrossFileReferences } from '../src/utils/workspaceScanner';
-import { offsetToPosition } from '../src/utils/textUtils';
+import { collectDitaFiles, findCrossFileReferences, referenceMatchesTarget } from '../src/utils/workspaceScanner';
+import { offsetToPosition, normalizeFsPath } from '../src/utils/textUtils';
+import { ReferenceOccurrence } from '../src/utils/referenceParser';
 import { KeySpaceService, KeyDefinition } from '../src/services/keySpaceService';
 
 function mockKeySpaceService(resolve: (keyName: string, contextFilePath: string) => KeyDefinition | null): KeySpaceService {
@@ -12,6 +13,78 @@ function mockKeySpaceService(resolve: (keyName: string, contextFilePath: string)
         resolveKey: async (keyName: string, contextFilePath: string) => resolve(keyName, contextFilePath),
     } as unknown as KeySpaceService;
 }
+
+function makeRef(type: ReferenceOccurrence['type'], value: string): ReferenceOccurrence {
+    return { type, value, valueStart: 0, valueEnd: value.length };
+}
+
+suite('referenceMatchesTarget', () => {
+    const contextFile = path.join(path.sep, 'ws', 'referencer.dita');
+    const targetFile = path.join(path.sep, 'ws', 'target.dita');
+    const normalizedTarget = normalizeFsPath(targetFile);
+
+    test('href resolving to the target file matches', async () => {
+        const matches = await referenceMatchesTarget(
+            makeRef('href', 'target.dita'), contextFile, normalizedTarget, undefined
+        );
+        assert.strictEqual(matches, true);
+    });
+
+    test('href resolving elsewhere does not match', async () => {
+        const matches = await referenceMatchesTarget(
+            makeRef('href', 'other.dita'), contextFile, normalizedTarget, undefined
+        );
+        assert.strictEqual(matches, false);
+    });
+
+    test('fragment-only href matches only when contextFile is the target itself', async () => {
+        const inTarget = await referenceMatchesTarget(
+            makeRef('href', '#someId'), targetFile, normalizedTarget, undefined
+        );
+        assert.strictEqual(inTarget, true);
+
+        const inOther = await referenceMatchesTarget(
+            makeRef('href', '#someId'), contextFile, normalizedTarget, undefined
+        );
+        assert.strictEqual(inOther, false);
+    });
+
+    test('conkeyref resolving to the target file matches', async () => {
+        const keySpaceService = mockKeySpaceService(() => ({
+            keyName: 'mykey', targetFile, sourceMap: targetFile,
+        }));
+        const matches = await referenceMatchesTarget(
+            makeRef('conkeyref', 'mykey/elemId'), contextFile, normalizedTarget, keySpaceService
+        );
+        assert.strictEqual(matches, true);
+    });
+
+    test('conkeyref resolving elsewhere does not match', async () => {
+        const keySpaceService = mockKeySpaceService(() => ({
+            keyName: 'mykey', targetFile: path.join(path.sep, 'ws', 'unrelated.dita'), sourceMap: contextFile,
+        }));
+        const matches = await referenceMatchesTarget(
+            makeRef('conkeyref', 'mykey/elemId'), contextFile, normalizedTarget, keySpaceService
+        );
+        assert.strictEqual(matches, false);
+    });
+
+    test('conkeyref without a KeySpaceService is excluded and logged', async () => {
+        const logs: string[] = [];
+        const matches = await referenceMatchesTarget(
+            makeRef('conkeyref', 'mykey/elemId'), contextFile, normalizedTarget, undefined, (msg) => logs.push(msg)
+        );
+        assert.strictEqual(matches, false);
+        assert.ok(logs.some(m => m.includes('mykey/elemId')));
+    });
+
+    test('keyref (no file part to verify) always matches', async () => {
+        const matches = await referenceMatchesTarget(
+            makeRef('keyref', 'somekey'), contextFile, normalizedTarget, undefined
+        );
+        assert.strictEqual(matches, true);
+    });
+});
 
 suite('offsetToPosition', () => {
     test('offset 0 is line 0 character 0', () => {

--- a/server/test/workspaceScanner.test.ts
+++ b/server/test/workspaceScanner.test.ts
@@ -280,8 +280,15 @@ suite('findCrossFileReferences', () => {
             const refPath = path.join(tmp, 'ref.ditamap');
             fs.writeFileSync(refPath, '<map><ph conkeyref="somekey/myId"/></map>');
 
-            const results = await findCrossFileReferences('myId', targetPath, [tmp]);
+            const logs: string[] = [];
+            const results = await findCrossFileReferences(
+                'myId', targetPath, [tmp], undefined, undefined, undefined, (msg) => logs.push(msg)
+            );
             assert.strictEqual(results.length, 0);
+            assert.ok(
+                logs.some(m => m.includes('somekey/myId')),
+                'skipping an unverifiable conkeyref should be logged so it is not silently dropped (regression)'
+            );
         } finally {
             fs.rmSync(tmp, { recursive: true, force: true });
         }

--- a/server/test/workspaceScanner.test.ts
+++ b/server/test/workspaceScanner.test.ts
@@ -5,6 +5,13 @@ import * as path from 'path';
 import { URI } from 'vscode-uri';
 import { collectDitaFiles, findCrossFileReferences } from '../src/utils/workspaceScanner';
 import { offsetToPosition } from '../src/utils/textUtils';
+import { KeySpaceService, KeyDefinition } from '../src/services/keySpaceService';
+
+function mockKeySpaceService(resolve: (keyName: string, contextFilePath: string) => KeyDefinition | null): KeySpaceService {
+    return {
+        resolveKey: async (keyName: string, contextFilePath: string) => resolve(keyName, contextFilePath),
+    } as unknown as KeySpaceService;
+}
 
 suite('offsetToPosition', () => {
     test('offset 0 is line 0 character 0', () => {
@@ -184,17 +191,17 @@ suite('findCrossFileReferences', () => {
         return filePath;
     }
 
-    test('returns empty array when no DITA files exist in workspace', () => {
+    test('returns empty array when no DITA files exist in workspace', async () => {
         const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ditacraft-ws-test-'));
         try {
-            const results = findCrossFileReferences('myId', path.join(tmp, 'target.dita'), [tmp]);
+            const results = await findCrossFileReferences('myId', path.join(tmp, 'target.dita'), [tmp]);
             assert.deepStrictEqual(results, []);
         } finally {
             fs.rmSync(tmp, { recursive: true, force: true });
         }
     });
 
-    test('href with file path that resolves to target file is included', () => {
+    test('href with file path that resolves to target file is included', async () => {
         const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ditacraft-ws-test-'));
         try {
             // target file
@@ -204,7 +211,7 @@ suite('findCrossFileReferences', () => {
             // referencing file — href points to target.dita#myId
             writeHrefFile(tmp, 'ref.ditamap', 'target.dita#myId');
 
-            const results = findCrossFileReferences('myId', targetPath, [tmp]);
+            const results = await findCrossFileReferences('myId', targetPath, [tmp]);
             assert.strictEqual(results.length, 1);
             assert.ok(results[0].uri.endsWith('ref.ditamap') || results[0].uri.includes('ref.ditamap'));
         } finally {
@@ -212,7 +219,7 @@ suite('findCrossFileReferences', () => {
         }
     });
 
-    test('href with file path that does not resolve to target file is excluded', () => {
+    test('href with file path that does not resolve to target file is excluded', async () => {
         const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ditacraft-ws-test-'));
         try {
             const targetPath = path.join(tmp, 'target.dita');
@@ -223,28 +230,28 @@ suite('findCrossFileReferences', () => {
             fs.writeFileSync(otherPath, '<topic id="myId"/>');
             writeHrefFile(tmp, 'ref.ditamap', 'other.dita#myId');
 
-            const results = findCrossFileReferences('myId', targetPath, [tmp]);
+            const results = await findCrossFileReferences('myId', targetPath, [tmp]);
             assert.strictEqual(results.length, 0);
         } finally {
             fs.rmSync(tmp, { recursive: true, force: true });
         }
     });
 
-    test('fragment-only ref inside target file is included', () => {
+    test('fragment-only ref inside target file is included', async () => {
         const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ditacraft-ws-test-'));
         try {
             // The fragment-only href lives inside the target file itself
             const targetPath = path.join(tmp, 'target.dita');
             fs.writeFileSync(targetPath, '<topic id="root"><topicref href="#myId"/></topic>');
 
-            const results = findCrossFileReferences('myId', targetPath, [tmp]);
+            const results = await findCrossFileReferences('myId', targetPath, [tmp]);
             assert.strictEqual(results.length, 1);
         } finally {
             fs.rmSync(tmp, { recursive: true, force: true });
         }
     });
 
-    test('fragment-only ref inside a different file is excluded', () => {
+    test('fragment-only ref inside a different file is excluded', async () => {
         const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ditacraft-ws-test-'));
         try {
             const targetPath = path.join(tmp, 'target.dita');
@@ -254,32 +261,60 @@ suite('findCrossFileReferences', () => {
             const otherPath = path.join(tmp, 'other.ditamap');
             fs.writeFileSync(otherPath, '<map><topicref href="#myId"/></map>');
 
-            const results = findCrossFileReferences('myId', targetPath, [tmp]);
+            const results = await findCrossFileReferences('myId', targetPath, [tmp]);
             assert.strictEqual(results.length, 0);
         } finally {
             fs.rmSync(tmp, { recursive: true, force: true });
         }
     });
 
-    test('conkeyref match is included by element ID regardless of key', () => {
+    test('conkeyref match is excluded without a KeySpaceService to verify it (regression)', async () => {
+        // Without a way to resolve the key, an element-ID text match alone is
+        // not proof the conkeyref actually targets this file — it must be
+        // excluded rather than reported as a possibly-false-positive reference.
         const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ditacraft-ws-test-'));
         try {
             const targetPath = path.join(tmp, 'target.dita');
             fs.writeFileSync(targetPath, '<topic id="myId"/>');
 
-            // conkeyref uses "somekey/myId" — element ID matches, so it must be included
             const refPath = path.join(tmp, 'ref.ditamap');
             fs.writeFileSync(refPath, '<map><ph conkeyref="somekey/myId"/></map>');
 
-            const results = findCrossFileReferences('myId', targetPath, [tmp]);
-            assert.strictEqual(results.length, 1);
-            assert.ok(results[0].uri.includes('ref.ditamap'));
+            const results = await findCrossFileReferences('myId', targetPath, [tmp]);
+            assert.strictEqual(results.length, 0);
         } finally {
             fs.rmSync(tmp, { recursive: true, force: true });
         }
     });
 
-    test('excludeUri parameter causes the specified file to be skipped', () => {
+    test('conkeyref resolving to the target file is included; resolving elsewhere is excluded (regression)', async () => {
+        const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ditacraft-ws-test-'));
+        try {
+            const targetPath = path.join(tmp, 'target.dita');
+            const unrelatedPath = path.join(tmp, 'unrelated.dita');
+            fs.writeFileSync(targetPath, '<topic id="myId"/>');
+            fs.writeFileSync(unrelatedPath, '<topic id="myId"/>');
+
+            const refPath = path.join(tmp, 'ref.ditamap');
+            fs.writeFileSync(refPath,
+                '<map><ph conkeyref="goodkey/myId"/><ph conkeyref="badkey/myId"/></map>');
+
+            const keySpaceService = mockKeySpaceService((keyName) => {
+                if (keyName === 'goodkey') return { keyName, targetFile: targetPath, sourceMap: targetPath };
+                if (keyName === 'badkey') return { keyName, targetFile: unrelatedPath, sourceMap: unrelatedPath };
+                return null;
+            });
+
+            const results = await findCrossFileReferences(
+                'myId', targetPath, [tmp], undefined, undefined, keySpaceService
+            );
+            assert.strictEqual(results.length, 1, 'only the conkeyref resolving to the target file should match');
+        } finally {
+            fs.rmSync(tmp, { recursive: true, force: true });
+        }
+    });
+
+    test('excludeUri parameter causes the specified file to be skipped', async () => {
         const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ditacraft-ws-test-'));
         try {
             const targetPath = path.join(tmp, 'target.dita');
@@ -290,18 +325,18 @@ suite('findCrossFileReferences', () => {
             const refUri = URI.file(refPath).toString();
 
             // Without excludeUri we get a result
-            const withoutExclude = findCrossFileReferences('myId', targetPath, [tmp]);
+            const withoutExclude = await findCrossFileReferences('myId', targetPath, [tmp]);
             assert.strictEqual(withoutExclude.length, 1);
 
             // With excludeUri pointing to ref.ditamap, that file is skipped
-            const withExclude = findCrossFileReferences('myId', targetPath, [tmp], refUri);
+            const withExclude = await findCrossFileReferences('myId', targetPath, [tmp], refUri);
             assert.strictEqual(withExclude.length, 0);
         } finally {
             fs.rmSync(tmp, { recursive: true, force: true });
         }
     });
 
-    test('documents parameter provides in-memory content instead of disk content', () => {
+    test('documents parameter provides in-memory content instead of disk content', async () => {
         const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ditacraft-ws-test-'));
         try {
             const targetPath = path.join(tmp, 'target.dita');
@@ -325,7 +360,7 @@ suite('findCrossFileReferences', () => {
                 },
             } as any;
 
-            const results = findCrossFileReferences('myId', targetPath, [tmp], undefined, stubDocuments);
+            const results = await findCrossFileReferences('myId', targetPath, [tmp], undefined, stubDocuments);
             assert.strictEqual(results.length, 1);
             assert.ok(results[0].uri.includes('ref.ditamap'));
         } finally {
@@ -333,7 +368,7 @@ suite('findCrossFileReferences', () => {
         }
     });
 
-    test('no matches returns empty array', () => {
+    test('no matches returns empty array', async () => {
         const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ditacraft-ws-test-'));
         try {
             const targetPath = path.join(tmp, 'target.dita');
@@ -343,7 +378,7 @@ suite('findCrossFileReferences', () => {
             const refPath = path.join(tmp, 'ref.ditamap');
             fs.writeFileSync(refPath, '<map><topicref href="target.dita#otherId"/></map>');
 
-            const results = findCrossFileReferences('myId', targetPath, [tmp]);
+            const results = await findCrossFileReferences('myId', targetPath, [tmp]);
             assert.deepStrictEqual(results, []);
         } finally {
             fs.rmSync(tmp, { recursive: true, force: true });

--- a/server/test/workspaceScanner.test.ts
+++ b/server/test/workspaceScanner.test.ts
@@ -394,6 +394,45 @@ suite('findCrossFileReferences', () => {
         }
     });
 
+    test('multiple conkeyrefs per file resolve concurrently without mismatching ref-to-result (regression)', async () => {
+        // Regression for parallelizing resolveKey calls: each ref's match
+        // result must still map back to that same ref's position, not get
+        // shuffled by concurrent resolution order.
+        const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ditacraft-ws-test-'));
+        try {
+            const targetPath = path.join(tmp, 'target.dita');
+            const unrelatedPath = path.join(tmp, 'unrelated.dita');
+            fs.writeFileSync(targetPath, '<topic id="myId"/>');
+            fs.writeFileSync(unrelatedPath, '<topic id="myId"/>');
+
+            const refPath = path.join(tmp, 'ref.ditamap');
+            const content =
+                '<map>' +
+                '<ph conkeyref="badkey1/myId"/>' +
+                '<ph conkeyref="goodkey/myId"/>' +
+                '<ph conkeyref="badkey2/myId"/>' +
+                '</map>';
+            fs.writeFileSync(refPath, content);
+
+            const keySpaceService = mockKeySpaceService((keyName) => {
+                if (keyName === 'goodkey') return { keyName, targetFile: targetPath, sourceMap: targetPath };
+                return { keyName, targetFile: unrelatedPath, sourceMap: unrelatedPath };
+            });
+
+            const results = await findCrossFileReferences(
+                'myId', targetPath, [tmp], undefined, undefined, keySpaceService
+            );
+
+            assert.strictEqual(results.length, 1, 'only the goodkey conkeyref should match');
+            const expectedOffset = content.indexOf('goodkey');
+            const expectedPos = offsetToPosition(content, expectedOffset);
+            assert.strictEqual(results[0].range.start.line, expectedPos.line);
+            assert.strictEqual(results[0].range.start.character, expectedPos.character);
+        } finally {
+            fs.rmSync(tmp, { recursive: true, force: true });
+        }
+    });
+
     test('excludeUri parameter causes the specified file to be skipped', async () => {
         const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ditacraft-ws-test-'));
         try {

--- a/server/test/workspaceValidation.test.ts
+++ b/server/test/workspaceValidation.test.ts
@@ -96,6 +96,27 @@ suite('workspaceValidation', () => {
             }
         });
 
+        test('does not misattribute a nested child id as the root id (regression)', async () => {
+            // The root <topic> has no id, but a nested <p> does. The file must
+            // not be indexed under the child's id — that would cause bogus
+            // cross-file duplicate-ID diagnostics if another file's unrelated
+            // element happened to share that id.
+            const tmpDir = makeTmpDir();
+            try {
+                fs.writeFileSync(
+                    path.join(tmpDir, 'child-id.dita'),
+                    '<topic><title>No root ID</title><body><p id="para1">text</p></body></topic>'
+                );
+
+                const idx = new WorkspaceIndex();
+                await idx.buildFull([tmpDir]);
+                assert.strictEqual(idx.rootIdIndex.size, 0,
+                    'file must not be indexed under a nested child element\'s id');
+            } finally {
+                cleanup(tmpDir);
+            }
+        });
+
         test('empty workspace returns empty index', async () => {
             const tmpDir = makeTmpDir();
             try {


### PR DESCRIPTION
Code review of the LSP server surfaced three correctness/security issues,
each fixed with regression tests:

- Path-traversal guard was only applied in keySpaceService.ts; hover,
  completion, definition, cross-reference validation, circular-reference
  detection, and the context-graph handler resolved user-authored href
  values without checking they stayed inside the workspace. Extracted the
  guard to a shared isPathWithinWorkspace() in textUtils.ts and applied it
  at every unguarded resolve+read/readdir site.
- keySpaceService's BFS deduplicated visited maps by path only, so a submap
  reached via two different mapref @keyscope values only had its keys
  registered under the first scope. Cached each map's own key definitions
  on first visit and register them under later scope encounters too.
- contentModelValidation's element-stack tracker unconditionally popped on
  a mismatched closing tag, desyncing the tree for the rest of the
  document. Now resyncs to the nearest matching ancestor, or leaves the
  stack untouched for a stray closing tag with no ancestor match.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QStkobe5KPqky2KYQz2axj