### PR TITLE
[release]: bump version to 0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,54 @@ All notable changes to the "DitaCraft" extension will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.2] - 2026-07-26
+
+### Added
+- **Knowledge Graph (graphify)** — `npm run graph` generates a queryable knowledge graph of the codebase into `docs/graph/` (`graph.json`, `GRAPH_REPORT.md`, `graph.svg`, an interactive studio viewer, and `flows.json` for execution-flow impact analysis) using local tree-sitter AST extraction (no LLM/API keys). Auto-regenerates during `npm run watch` and on every push to `main` via the `knowledge-graph` GitHub Actions workflow. See "Using the Knowledge Graph" in `CLAUDE.md`.
+
+### Fixed
+
+**Security / path traversal:**
+- Extracted a shared `isPathWithinWorkspace()` guard and applied it consistently across hover, completion, definition, cross-reference validation, circular-reference detection, document links, and the MCP context-graph handler — several of these previously resolved user-authored `href` values without checking they stayed inside the workspace.
+- Documents opened outside every configured workspace folder (e.g. via File > Open) no longer have workspace-boundary checks incorrectly applied to their same-directory sibling references.
+
+**Key space / cross-file references:**
+- Diamond-shaped `@keyscope` map graphs (a submap reached twice via different scope chains) no longer lose keys defined further down the re-visited submap's tree.
+- Fixed Windows case-mismatch in key-space path comparisons (`resolveKey`, `explainKey`, BFS visited-set, cache invalidation) that could silently miss scope-aware key lookups and cache invalidation on Windows.
+- Rename and Find All References now verify `conkeyref` matches actually resolve to the target file via the key space before rewriting/reporting them, instead of matching on element-ID text alone across the whole workspace; unverifiable matches are now logged instead of silently skipped.
+- `resolveKey` calls in cross-file reference and rename loops are now parallelized instead of awaited one at a time.
+
+**Validation pipeline races and caching:**
+- A timed-out or cancelled async validation phase (cross-reference, circular-reference, RNG) no longer caches its empty fallback as a valid result, which had been able to mask broken links for up to 5 minutes.
+- Cancellation/budget-exceeded early exits now still apply severity overrides, comment suppression, and the diagnostics cap.
+- Profiling validation now validates against an immutable per-document subject-scheme snapshot instead of shared, possibly cross-document, service state.
+- A key-space build racing with a file invalidation no longer re-caches stale data after the invalidation ran.
+- The AI Quick Fix feature now checks the document version (and closed state) before applying its edit, so a multi-second LLM call can no longer apply a fix against stale line coordinates.
+- `getDocumentSettings()` no longer permanently poisons a document's settings cache after a single transient configuration-fetch failure.
+- Saving a `.dita` topic file now correctly invalidates cached cross-reference diagnostics in other open documents, not just when a map file changes.
+
+**Editing / navigation:**
+- Fixed a recurring bug class where a stray or mismatched closing tag desynced a name-keyed element stack, corrupting later lookups — found and fixed across `contentModelValidation.ts`, `symbols.ts` (Outline and workspace symbols), `folding.ts`, and `completion.ts`; consolidated into a shared `resyncStackToMatch()` helper.
+- `fragmentValidator.ts` (used by AI Quick Fix) now reads per-document settings instead of stale global defaults.
+- Fixed the DITA-SCH-011 quick fix rewriting the wrong `<image>` element's `alt` attribute when a later image existed in the document.
+- Added missing `parml`, `screen`, and `syntaxdiagram` to the `body`/`conbody`/`section` content models, which had been rejecting elements the completion provider itself suggested.
+- `workspaceValidation.ts`'s root-ID extraction no longer matches a nested child's `id` instead of the topic's actual root element.
+- DITA-OT progress percentages (absolute) are no longer misapplied as cumulative increments in publish/preview/validate-guide, which had overshot the progress bar.
+
+### Changed
+- Consolidated duplicated reference-matching, tag-stack resync, and progress-reporting logic into shared helpers to keep the fixes above from re-diverging.
+- Removed 41 stale compiled `.js`/`.js.map` files that had been committed alongside their TypeScript sources; `.gitignore` now guards against recommitting them.
+
+### Dependencies
+- **@anthropic-ai/sdk** 0.105.0 → 0.112.4
+- **openai** → 6.48.0
+- **vscode-languageclient** 10.0.0 → 10.0.1
+- **fast-xml-parser** → 5.10.1
+- **typesxml** 2.2.0 → 2.2.1
+- **c8** 11.0.0 → 12.0.0
+- **@types/node**, **eslint**, **typescript-eslint**, **sinon**, **@types/sinon** and other dev-dependency group bumps
+- **actions/setup-node** GitHub Action 6 → 7
+
 ## [0.8.1] - 2026-06-24
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![VS Code](https://img.shields.io/badge/VS%20Code-1.80+-blue.svg)](https://code.visualstudio.com/)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![CI](https://github.com/jyjeanne/ditacraft/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/jyjeanne/ditacraft/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.8.0-orange.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.8.2-orange.svg)](CHANGELOG.md)
 
 DitaCraft is a comprehensive Visual Studio Code extension for editing and publishing DITA (Darwin Information Typing Architecture) content. It provides syntax highlighting, real-time validation, smart navigation, AI-powered assistance, an MCP server for external AI agents, and seamless integration with DITA-OT for multi-format publishing.
 
@@ -47,7 +47,7 @@ DitaCraft is a comprehensive Visual Studio Code extension for editing and publis
 🛡️ **Rate Limiting** - Built-in DoS protection for validation operations
 🤖 **AI-Powered Features** - GitHub Copilot integration: `@ditacraft` chat participant, AI Quick Fix, AI Completion, map restructuring, and multi-provider cascade (Copilot → Anthropic → OpenAI → Ollama)
 🔌 **MCP Server** - Standalone Model Context Protocol server for external AI agents (opencode, Claude Desktop, Cursor, Continue) — 6 tools, 3 resources, zero VS Code dependency
-🧪 **1564+ Tests** - Extensively tested with comprehensive integration, security, and LSP server tests
+🧪 **1770+ Tests** - Extensively tested with comprehensive integration, security, and LSP server tests
 📚 **DITA User Guide** - Comprehensive documentation written in DITA (~80 files, bookmap structure)
 
 ## Features
@@ -678,7 +678,7 @@ Track progress: see the [Roadmap](ROADMAP.md#milestone-7-publishing-enhancements
 
 DitaCraft exposes its DITA intelligence — validation, key space, context snapshots — over the **Model Context Protocol (MCP)**, letting external AI coding agents read and query your DITA workspace.
 
-> **Status:** MCP server is **available** in v0.8.0 (current). Build with `npm run build-standalone` to produce `dist/mcp-server.js` and `dist/lsp-server.js`.
+> **Status:** MCP server is **available** since v0.8.0 (current release: v0.8.2). Build with `npm run build-standalone` to produce `dist/mcp-server.js` and `dist/lsp-server.js`.
 
 ### What is MCP?
 
@@ -1108,7 +1108,49 @@ The user guide demonstrates DitaCraft's own capabilities - you can open it in VS
 
 ## Recent Updates
 
-### Version 0.8.0 (Current)
+### Version 0.8.2 (Current)
+**Security Hardening, Key Space & Validation Race Fixes, Knowledge Graph**
+
+**Added:**
+- **Knowledge Graph (graphify)** — `npm run graph` generates a queryable codebase graph (`docs/graph/graph.json`, `GRAPH_REPORT.md`, `graph.svg`, interactive studio viewer, `flows.json`) via local tree-sitter AST extraction — no LLM/API keys. Auto-regenerates in `npm run watch` and on every push to `main`.
+
+**Fixed — Security / path traversal:**
+- Shared `isPathWithinWorkspace()` guard applied consistently across hover, completion, definition, cross-reference validation, circular-reference detection, document links, and the MCP context-graph handler
+- Documents opened outside every workspace folder no longer misapply workspace-boundary checks to same-directory sibling references
+
+**Fixed — Key space / cross-file references:**
+- Diamond-shaped `@keyscope` map graphs no longer lose keys from re-visited submaps
+- Windows case-mismatch in key-space path comparisons resolved (could silently miss key lookups/cache invalidation)
+- Rename and Find All References now verify `conkeyref` matches resolve to the target file via the key space before rewriting/reporting, instead of matching on element-ID text alone
+- Cross-file reference/rename `resolveKey` calls now run in parallel
+
+**Fixed — Validation pipeline races and caching:**
+- Timed-out/cancelled async validation phases no longer cache their empty fallback as a valid result (could mask broken links up to 5 minutes)
+- Cancellation/budget-exceeded exits now still apply severity overrides, comment suppression, and the diagnostics cap
+- Profiling validation now uses an immutable per-document subject-scheme snapshot instead of shared cross-document state
+- AI Quick Fix now checks document version/closed state before applying an edit, preventing stale-edit application after a slow LLM call
+- Settings cache no longer permanently poisoned by a single transient configuration-fetch failure
+- Saving a `.dita` topic now correctly invalidates cross-reference diagnostics cached in other open documents
+
+**Fixed — Editing / navigation:**
+- Consolidated a recurring mismatched-closing-tag stack-desync bug (found across content model validation, symbols, folding, completion) into a shared `resyncStackToMatch()` helper
+- DITA-SCH-011 quick fix no longer rewrites the wrong `<image>` element
+- `body`/`conbody`/`section` content models now accept `parml`, `screen`, `syntaxdiagram`
+- DITA-OT progress percentages no longer misapplied as cumulative increments
+
+**Dependencies:** `@anthropic-ai/sdk` → 0.112.4, `vscode-languageclient` → 10.0.1, `fast-xml-parser` → 5.10.1, `typesxml` → 2.2.1, `c8` → 12.0.0, plus dev-dependency and `actions/setup-node` bumps
+
+**1770+ Total Tests** — Client (710) + Server (977) + MCP (83)
+
+### Version 0.8.1
+**Preview Auto-Refresh Fix & Build Tooling**
+- **Preview auto-refresh on save** (#96) — `ditacraft.previewAutoRefresh` now actually re-renders the preview when the previewed source file is saved (debounced 500ms, serialized refreshes, focus-preserving)
+- **CommonJS test build fix** — resolved a `MODULE_TYPELESS_PACKAGE_JSON` failure in the test runner
+- **vscode-languageclient 10 resolution fix** — corrected `moduleResolution` for the new `exports`-based package layout
+- **Minimum VS Code version raised to 1.125.0** to match the bumped `@types/vscode`, restoring `vsce package`
+- **Dependencies** — `vscode-languageclient` 9.0.1 → 10.0.0, `@vscode/test-electron` 2.5.2 → 3.0.0, `@types/node` 25.9.3 → 26.0.0, `actions/checkout` 6 → 7
+
+### Version 0.8.0
 **MCP Server, Standalone LSP Server & Standalone Bundles**
 
 **MCP Server (`mcp/`):**
@@ -1341,7 +1383,9 @@ We have an exciting roadmap planned for DitaCraft! See our detailed [ROADMAP.md]
 - **v0.7.2** - Severity Overrides, Custom Rules, Architecture Improvements (1375+ tests) ✅ **COMPLETE**
 - **v0.7.3** - Key space algorithm completion (all 7 gaps), pipeline budget/ReDoS, TypeScript 6.0, TypesXML 2.0 (1564+ tests) ✅ **COMPLETE**
 - **v0.7.4** - AI Integration: Copilot, Anthropic, OpenAI, Ollama; @ditacraft chat participant, AI Quick Fix, AI Completion ✅ **COMPLETE**
-- **v0.8.0** - MCP Server (6 tools, 3 resources), Standalone LSP Server, standalone bundles ✅ **CURRENT**
+- **v0.8.0** - MCP Server (6 tools, 3 resources), Standalone LSP Server, standalone bundles ✅ **COMPLETE**
+- **v0.8.1** - Preview auto-refresh fix, build tooling fixes ✅ **COMPLETE**
+- **v0.8.2** - Security hardening, key space & validation race fixes, knowledge graph (1770+ tests) ✅ **CURRENT**
 - **v0.9.0** - Publishing Enhancements (profiles, DITAVAL editor)
 
 ## Contributing

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 This document outlines the planned features, improvements, and future direction for DitaCraft. It's designed to help users and contributors understand where the project is heading and find opportunities to contribute.
 
-## Current Status (v0.8.0)
+## Current Status (v0.8.2)
 
 DitaCraft is a production-ready VS Code extension for DITA editing and publishing with the following complete features:
 
@@ -147,8 +147,66 @@ DitaCraft is a production-ready VS Code extension for DITA editing and publishin
 | **LSP: contextGraph Handler** | Complete | 100% |
 | **LSP: fragmentValidator Handler** | Complete | 100% |
 | **LSP: contextSnapshot Handler (Levels 1/2/3)** | Complete | 100% |
+| **Knowledge Graph (graphify)** | Complete | 100% |
+| **Shared isPathWithinWorkspace() Guard (all LSP handlers)** | Complete | 100% |
+| **Key Space: Diamond-Scope Revisit Fix** | Complete | 100% |
+| **Windows Path Case-Fold Normalization** | Complete | 100% |
+| **Conkeyref-Verified Rename/Find-References** | Complete | 100% |
+| **Validation Cache-Poisoning Fixes (timeout/cancel/race)** | Complete | 100% |
+| **Per-Document Subject-Scheme Snapshot Isolation** | Complete | 100% |
+| **AI Quick Fix Stale-Edit Guard** | Complete | 100% |
+| **Shared resyncStackToMatch() Tag-Desync Fix** | Complete | 100% |
 
-### Recent Changes (v0.8.0)
+### Recent Changes (v0.8.2)
+
+**Security & Path Traversal:**
+- Extracted a shared `isPathWithinWorkspace()` guard and applied it at every previously-unguarded `href`-resolution site: hover, completion, definition, cross-reference validation, circular-reference detection, document links, and the MCP `dita_map_structure`/context-graph handler
+- Documents opened outside every configured workspace folder no longer have workspace-boundary checks incorrectly applied to their same-directory sibling references (new `effectiveWorkspaceFolders()` permissive fallback)
+
+**Key Space & Cross-File References:**
+- Diamond-shaped `@keyscope` map graphs (a submap reached twice via different scope chains) no longer lose keys defined further down the re-visited submap's tree
+- Fixed Windows case-mismatch in key-space path comparisons (`resolveKey`, `explainKey`, BFS visited-set, cache invalidation) via consistent `normalizeFsPath()` usage
+- Rename and Find All References now verify `conkeyref` matches actually resolve to the target file via the key space before rewriting/reporting, instead of matching on element-ID text alone across the workspace
+- `resolveKey` calls in cross-file reference/rename loops now run in parallel via `Promise.all`
+
+**Validation Pipeline Race & Cache Fixes (deep code review, 2 passes):**
+- A timed-out or cancelled async validation phase (cross-reference, circular-reference, RNG) no longer caches its empty fallback as a valid result — previously could mask broken links for up to 5 minutes
+- Cancellation/budget-exceeded early exits now still apply severity overrides, comment suppression, and the diagnostics cap via a single `finalizeDiagnostics` path
+- Profiling validation now validates against an immutable per-document subject-scheme snapshot (`SubjectSchemeService.snapshotFor()`, memoized) instead of shared, possibly cross-document, service state
+- A key-space build racing with invalidation no longer re-caches stale data; `rootMapCache` writes respect the same generation guard as the key space cache
+- AI Quick Fix now records `document.version` (and checks `isClosed`) before a multi-second LLM call and refuses to apply a stale edit
+- `getDocumentSettings()` no longer permanently poisons a document's settings cache after a single transient configuration-fetch failure
+- Saving a `.dita` topic file now correctly invalidates cached cross-reference diagnostics in other open documents, not just when a map file changes
+- `findRootMap` bounded to 3 levels for files outside every workspace folder (was walking to the filesystem root)
+
+**Editing / Navigation:**
+- Consolidated a recurring mismatched-closing-tag stack-desync bug — independently found and fixed across `contentModelValidation.ts`, `symbols.ts` (Outline + workspace symbols), `folding.ts`, and `completion.ts` — into a shared `resyncStackToMatch()` primitive in `utils/tagStack.ts`
+- Fixed the DITA-SCH-011 quick fix rewriting the wrong `<image>` element's `alt` attribute
+- Added missing `parml`, `screen`, `syntaxdiagram` to the `body`/`conbody`/`section` content models
+- Fixed `workspaceValidation.ts` root-ID extraction matching a nested child's `id` instead of the topic's actual root element
+- DITA-OT progress percentages (absolute) no longer misapplied as cumulative increments in publish/preview/validate-guide
+
+**Added — Knowledge Graph:**
+- `@sentropic/graphify` devDependency (local tree-sitter AST extraction, no LLM/API keys); `npm run graph` publishes `graph.json`, `GRAPH_REPORT.md`, `graph.svg`, an interactive studio viewer, and `flows.json` to `docs/graph/`
+- Auto-regenerates via `watch:graph` (included in `npm run watch`) and the `knowledge-graph` GitHub Actions workflow on every push to `main`
+
+**Hygiene:**
+- Removed 41 stale compiled `.js`/`.js.map` files committed alongside their TypeScript sources; `.gitignore` now guards against recommitting them
+- Deduplicated `isDitaUri()` into `src/utils/constants.ts`
+
+**Dependencies:** `@anthropic-ai/sdk` 0.105.0 → 0.112.4, `openai` → 6.48.0, `vscode-languageclient` 10.0.0 → 10.0.1, `fast-xml-parser` → 5.10.1, `typesxml` 2.2.0 → 2.2.1, `c8` 11.0.0 → 12.0.0, plus dev-dependency group bumps and `actions/setup-node` 6 → 7
+
+**1770+ Total Tests** — Client (710) + Server (977) + MCP (83)
+
+### Previous Changes (v0.8.1)
+
+- **Preview auto-refresh on save** (#96) — `ditacraft.previewAutoRefresh` was read from configuration but never wired to a save event; the preview now re-renders when the previewed source file is saved. Rapid saves are debounced (500ms) and refreshes are serialized so only one DITA-OT publish runs at a time; refresh preserves editor focus and updates the panel without pulling it to the foreground. Path matching is case-insensitive on Windows/macOS.
+- **CommonJS test build fix** — `tsc -p ./` now emits CommonJS again (Node16 module resolution), fixing a `MODULE_TYPELESS_PACKAGE_JSON` failure in the test runner
+- **vscode-languageclient 10 resolution fix** — switched TypeScript `moduleResolution` so the client's `exports`-based `vscode-languageclient/node` entrypoint resolves under the new package layout
+- **Minimum VS Code version raised to 1.125.0** (`engines.vscode`) to match the bumped `@types/vscode`, restoring `vsce package`
+- **Dependencies** — `vscode-languageclient` 9.0.1 → 10.0.0, `@vscode/test-electron` 2.5.2 → 3.0.0, `@types/node` 25.9.3 → 26.0.0, `actions/checkout` 6 → 7
+
+### Previous Changes (v0.8.0)
 
 **MCP Server & Standalone Distribution:**
 - **MCP Server** — Standalone process exposing 6 MCP tools (`dita_validate`, `dita_context_snapshot`, `dita_key_space`, `dita_map_structure`, `dita_resolve_reference`, `dita_explain_key`) and 3 MCP resources (`dita://workspace/maps`, `dita://workspace/diagnostics`, `dita://workspace/keys`) over stdio JSON-RPC. No VS Code dependency — agents spawn `node dist/mcp-server.js`.
@@ -579,7 +637,7 @@ DitaCraft is a production-ready VS Code extension for DITA editing and publishin
 - [x] npm run build-standalone command
 - [x] LSP smoke test via stdio
 
-### Refactoring Tools (deferred to v0.8.1)
+### Refactoring Tools (deferred to v0.9.0)
 - [ ] Rename key across all usages
 - [ ] Rename element ID with reference updates
 - [ ] Move topic with reference updates
@@ -731,9 +789,11 @@ Have ideas for features not listed here? We'd love to hear from you!
 | v0.7.2 | Severity overrides, custom rules, architecture improvements, 1375+ Tests | Released |
 | v0.7.3 | Key space algorithm completion (all 7 gaps), pipeline budget/ReDoS, TS 6.0, TypesXML 2.0, 1537+ Tests | Released |
 | v0.7.4 | AI integration (Phases 1-3): LLM router, circuit breaker, @ditacraft chat, F2/F3/F4 AI features, 1537+ Tests | Released |
-| v0.8.0 | MCP server (6 tools, 3 resources), standalone LSP distribution, 1591+ Tests | **Current** |
+| v0.8.0 | MCP server (6 tools, 3 resources), standalone LSP distribution, 1591+ Tests | Released |
+| v0.8.1 | Preview auto-refresh fix, build/dependency tooling fixes | Released |
+| v0.8.2 | Security hardening, key space/validation race fixes, knowledge graph, 1770+ Tests | **Current** |
 | v0.9.0 | Refactoring & publishing enhancements | Planned |
 
 ---
 
-*Last updated: June 2026 (v0.8.0 — MCP server with 6 tools/3 resources, standalone LSP distribution, 67 MCP tests, 1591+ total tests)*
+*Last updated: July 2026 (v0.8.2 — security hardening, key space/validation race fixes, knowledge graph tooling, 1770+ total tests)*

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ditacraft",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ditacraft",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.112.4",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ditacraft",
   "displayName": "DitaCraft",
   "description": "Best way to edit and publish your DITA files - Complete DITA editing and publishing solution for VS Code",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "publisher": "JeremyJeanne",
   "author": {
     "name": "Jeremy Jeanne",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ditacraft-lsp-server",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ditacraft-lsp-server",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "dependencies": {
         "fast-xml-parser": "^5.5.12",
         "salve-annos": "^1.2.4",

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ditacraft-lsp-server",
   "description": "DitaCraft DITA Language Server",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "private": true,
   "main": "./out/server.js",
   "scripts": {


### PR DESCRIPTION
Bumps client and server package versions to 0.8.2 and adds the
CHANGELOG entry summarizing the security/path-traversal, key-space,
validation-race, and editing-desync fixes plus the new knowledge
graph tooling merged since 0.8.1.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014ie2MbGAtTq4QJMP4KCY3h