### PR TITLE
fix(server): eliminate ReDoS in entity-expansion pre-check (#125)

### DIFF
--- a/server/src/features/validation.ts
+++ b/server/src/features/validation.ts
@@ -127,7 +127,13 @@ function hasNonPredefinedEntityRef(value: string): boolean {
  * Locate a DOCTYPE's internal subset (the `[ ... ]` block) using a single
  * linear scan — quote-aware so a `]` or `>` inside a quoted literal (e.g. an
  * entity value) doesn't end the scan early, matching the intent of the
- * regex this replaces.
+ * regex this replaces. XML comments (`<!-- ... -->`) are skipped wholesale
+ * rather than scanned character-by-character: unlike the backtracking regex
+ * this replaces, a linear quote-toggle scan cannot recover from a lone
+ * unmatched quote (e.g. an apostrophe in prose like "don't"), so without
+ * this a single such comment would desync the scan and make it treat the
+ * rest of the document — including the real closing `]`/`>` — as still
+ * "inside a quote", silently disabling the entity-expansion/XXE check.
  *
  * The previous implementation used `<!DOCTYPE\s[\s\S]*?\[(...)*\]\s*>` —
  * a lazy `[\s\S]*?` that, on a DOCTYPE with no internal subset, searched
@@ -157,6 +163,12 @@ function extractDoctypeInternalSubset(
             if (ch === quote) quote = null;
             continue;
         }
+        if (text.startsWith('<!--', i)) {
+            const closeIdx = text.indexOf('-->', i + 4);
+            if (closeIdx === -1) return null; // unterminated comment — malformed
+            i = closeIdx + 2; // loop's i++ lands just past '-->'
+            continue;
+        }
         if (ch === '"' || ch === '\'') {
             quote = ch;
         } else if (ch === '[') {
@@ -173,7 +185,9 @@ function extractDoctypeInternalSubset(
 /**
  * Scan forward from just after a DOCTYPE's opening `[`, tracking nested
  * brackets and quotes, to find the matching `]`. Linear in the subset's
- * length — no alternation, no backtracking.
+ * length — no alternation, no backtracking. Comments are skipped wholesale
+ * (see {@link extractDoctypeInternalSubset}) so a stray unmatched quote in
+ * comment prose can't desync the quote-toggle tracking.
  */
 function extractBracketedSubset(text: string, subsetStart: number): { subset: string; offset: number } | null {
     let depth = 1;
@@ -183,6 +197,12 @@ function extractBracketedSubset(text: string, subsetStart: number): { subset: st
         const ch = text[i];
         if (quote) {
             if (ch === quote) quote = null;
+            continue;
+        }
+        if (text.startsWith('<!--', i)) {
+            const closeIdx = text.indexOf('-->', i + 4);
+            if (closeIdx === -1) return null; // unterminated comment — malformed
+            i = closeIdx + 2; // loop's i++ lands just past '-->'
             continue;
         }
         if (ch === '"' || ch === '\'') {

--- a/server/src/features/validation.ts
+++ b/server/src/features/validation.ts
@@ -69,15 +69,16 @@ export function validateDITADocument(
     return diagnostics;
 }
 
-// Regex to extract the DOCTYPE internal subset (content between [ and ]).
-// Uses quote-aware alternation so a ']>' sequence inside a quoted entity value
-// does not terminate the match prematurely and bypass the entity security checks.
-const DOCTYPE_INTERNAL_SUBSET_RE = /<!DOCTYPE\s[\s\S]*?\[((\"[^\"]*\"|'[^']*'|[^\]])*)\]\s*>/i;
+// Regex to locate the start of a DOCTYPE declaration. Only used to find where
+// to begin the linear internal-subset scan below — never to match the whole
+// declaration, so it can't itself become a backtracking hazard.
+const DOCTYPE_START_RE = /<!DOCTYPE\s/i;
 
-// Regex to match ALL ENTITY declarations (both internal and external) for counting.
-// Uses quote-aware alternation to avoid terminating early on '>' inside SYSTEM ids.
-// Captures: (1) optional % for parameter entities, (2) entity name.
-const ENTITY_ANY_RE = /<!ENTITY\s+(%\s+)?(\S+)\s+(?:"[^"]*"|'[^']*'|[^>])*>/gi;
+// Regex used only to COUNT entity declarations (both internal and external).
+// Deliberately a bare `<!ENTITY` search rather than a full declaration match
+// (which would need alternation up to a closing '>' — see #125) so counting
+// can never itself become a backtracking hazard.
+const ENTITY_COUNT_RE = /<!ENTITY\s/gi;
 
 // Regex to match internal ENTITY declarations with a quoted value.
 // Captures: (1) optional %, (2) name, (3) quote char, (4) value.
@@ -123,6 +124,81 @@ function hasNonPredefinedEntityRef(value: string): boolean {
 }
 
 /**
+ * Locate a DOCTYPE's internal subset (the `[ ... ]` block) using a single
+ * linear scan — quote-aware so a `]` or `>` inside a quoted literal (e.g. an
+ * entity value) doesn't end the scan early, matching the intent of the
+ * regex this replaces.
+ *
+ * The previous implementation used `<!DOCTYPE\s[\s\S]*?\[(...)*\]\s*>` —
+ * a lazy `[\s\S]*?` that, on a DOCTYPE with no internal subset, searched
+ * past the declaration into the rest of the document for the next stray
+ * `[`. A `[` far away (e.g. a JSON array inside a `<codeblock>`) combined
+ * with enough quoted-looking content for the starred alternation to
+ * backtrack over made the regex hang indefinitely on ordinary, well-formed
+ * documents (catastrophic backtracking — see #125). A hand-rolled scan
+ * can't backtrack, so it's immune by construction, and — as a side effect
+ * of being correct — it also stops considering a `[` outside the DOCTYPE
+ * declaration itself as the start of an internal subset.
+ *
+ * Returns the raw subset text, its offset in `text`, and the offset of the
+ * `<!DOCTYPE` keyword itself — or null when there is no DOCTYPE, or the
+ * DOCTYPE has no internal subset (or is malformed).
+ */
+function extractDoctypeInternalSubset(
+    text: string
+): { subset: string; offset: number; doctypeOffset: number } | null {
+    const doctypeStart = DOCTYPE_START_RE.exec(text);
+    if (!doctypeStart) return null;
+
+    let quote: string | null = null;
+    for (let i = doctypeStart.index + doctypeStart[0].length; i < text.length; i++) {
+        const ch = text[i];
+        if (quote) {
+            if (ch === quote) quote = null;
+            continue;
+        }
+        if (ch === '"' || ch === '\'') {
+            quote = ch;
+        } else if (ch === '[') {
+            const bracketed = extractBracketedSubset(text, i + 1);
+            return bracketed ? { ...bracketed, doctypeOffset: doctypeStart.index } : null;
+        } else if (ch === '>') {
+            // DOCTYPE closes with no internal subset.
+            return null;
+        }
+    }
+    return null; // Unterminated DOCTYPE — no subset to report.
+}
+
+/**
+ * Scan forward from just after a DOCTYPE's opening `[`, tracking nested
+ * brackets and quotes, to find the matching `]`. Linear in the subset's
+ * length — no alternation, no backtracking.
+ */
+function extractBracketedSubset(text: string, subsetStart: number): { subset: string; offset: number } | null {
+    let depth = 1;
+    let quote: string | null = null;
+    let i = subsetStart;
+    for (; i < text.length; i++) {
+        const ch = text[i];
+        if (quote) {
+            if (ch === quote) quote = null;
+            continue;
+        }
+        if (ch === '"' || ch === '\'') {
+            quote = ch;
+        } else if (ch === '[') {
+            depth++;
+        } else if (ch === ']') {
+            depth--;
+            if (depth === 0) break;
+        }
+    }
+    if (depth !== 0) return null; // Unterminated subset — malformed DOCTYPE.
+    return { subset: text.slice(subsetStart, i), offset: subsetStart };
+}
+
+/**
  * Defense-in-depth pre-check for dangerous entity patterns in DOCTYPE.
  * Detects: recursive entity expansion (billion laughs), XXE (external entities),
  * and excessive entity counts — before content reaches the XML parser.
@@ -132,16 +208,15 @@ function checkEntityExpansion(
     textDocument: TextDocument,
     diagnostics: Diagnostic[]
 ): void {
-    const subsetMatch = DOCTYPE_INTERNAL_SUBSET_RE.exec(text);
-    if (!subsetMatch) {
+    const subsetResult = extractDoctypeInternalSubset(text);
+    if (!subsetResult) {
         return;
     }
 
-    const subset = subsetMatch[1];
-    const subsetOffset = subsetMatch.index + subsetMatch[0].indexOf('[') + 1;
+    const { subset, offset: subsetOffset, doctypeOffset } = subsetResult;
 
     // Count ALL entity declarations (internal + external)
-    const countRegex = new RegExp(ENTITY_ANY_RE.source, ENTITY_ANY_RE.flags);
+    const countRegex = new RegExp(ENTITY_COUNT_RE.source, ENTITY_COUNT_RE.flags);
     let totalEntityCount = 0;
     while (countRegex.exec(subset) !== null) {
         totalEntityCount++;
@@ -184,7 +259,6 @@ function checkEntityExpansion(
 
     // Check for excessive entity count (includes both internal and external)
     if (totalEntityCount > MAX_ENTITY_COUNT) {
-        const doctypeOffset = subsetMatch.index;
         const pos = textDocument.positionAt(doctypeOffset);
         diagnostics.push({
             severity: DiagnosticSeverity.Warning,

--- a/server/test/validation.test.ts
+++ b/server/test/validation.test.ts
@@ -764,5 +764,28 @@ suite('validateDITADocument', () => {
                 assert.ok(Array.isArray(diags));
             });
         });
+
+        // Regression test: the linear quote-tracking scan that replaced the
+        // ReDoS-prone regex (#125) cannot backtrack past an unmatched quote the
+        // way the old regex could. A DTD comment containing a single apostrophe
+        // (ordinary English prose) used to desync the scan and make it silently
+        // treat the rest of the document as "inside a quote", skipping the real
+        // closing `]`/`>` and disabling the entity-expansion/XXE check entirely.
+        test('a comment with an unmatched apostrophe in the internal subset does not suppress external-entity detection', () => {
+            const xml = [
+                '<!DOCTYPE topic [',
+                "<!-- Don't add entities here -->",
+                '<!ENTITY xxe SYSTEM "file:///etc/passwd">',
+                ']>',
+                '<topic id="t1"><title>T</title></topic>',
+            ].join('\n');
+            const diags = validate(xml);
+            const externalDiags = diags.filter(d => d.code === 'DITA-SEC-002');
+            assert.strictEqual(
+                externalDiags.length,
+                1,
+                'external SYSTEM entity should still be flagged despite the apostrophe in the preceding comment'
+            );
+        });
     });
 });

--- a/server/test/validation.test.ts
+++ b/server/test/validation.test.ts
@@ -698,5 +698,71 @@ suite('validateDITADocument', () => {
             const excessDiags = diags.filter(d => d.code === 'DITA-SEC-003');
             assert.strictEqual(excessDiags.length, 1, 'external entities should be counted toward the limit');
         });
+
+        // Regression tests for #125: a DOCTYPE with no internal subset used to
+        // make the entity-expansion pre-check scan past the declaration for the
+        // next stray '[' anywhere in the document, then backtrack catastrophically
+        // trying to match content shaped like a mix of nested brackets and
+        // multiple quoted "key": "value" pairs (e.g. JSON inside a <codeblock>).
+        suite('ReDoS resistance (#125)', () => {
+            test('does not hang on a DOCTYPE without internal subset followed by JSON-like codeblock content', function () {
+                this.timeout(2000);
+                const xml = [
+                    '<!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">',
+                    '<topic id="t1"><title>T</title><body><p>',
+                    '<codeblock xml:space="preserve">',
+                    '[',
+                    '  {',
+                    '    "name": "org.dita.docbook",',
+                    '    "description": "Convert DITA to DocBook.",',
+                    '    "keywords": ["DocBook"],',
+                    '    "homepage": "https://github.com/dita-ot/org.dita.docbook/",',
+                    '    "vers": "2.3.0",',
+                    '    "license": "Apache-2.0",',
+                    '    "deps": [',
+                    '      {',
+                    '        "name": "org.dita.base",',
+                    '        "req": ">=2.3.0"',
+                    '      }',
+                    '    ],',
+                    '    "url": "https://github.com/dita-ot/org.dita.docbook/archive/2.3.zip",',
+                    '    "cksum": "eaf06b0dca8d942bd4152615e39ee8cfb73a624b96d70e10ab269ed6f8a13e21"',
+                    '  }',
+                    ']',
+                    '</codeblock>',
+                    '</p></body></topic>',
+                ].join('\n');
+                const t0 = Date.now();
+                const diags = validate(xml);
+                assert.ok(Date.now() - t0 < 1000, 'validation should complete quickly, not hang');
+                assert.ok(Array.isArray(diags));
+            });
+
+            test('does not hang when the document has no DOCTYPE at all but contains bracket-heavy content', function () {
+                this.timeout(2000);
+                const xml = [
+                    '<topic id="t1"><title>T</title><body><p><codeblock>',
+                    '[{"a":"1","b":"2","c":["x","y"],"d":{"e":"f"}}]'.repeat(20),
+                    '</codeblock></p></body></topic>',
+                ].join('\n');
+                const t0 = Date.now();
+                const diags = validate(xml);
+                assert.ok(Date.now() - t0 < 1000, 'validation should complete quickly, not hang');
+                assert.ok(Array.isArray(diags));
+            });
+
+            test('a malformed/unterminated internal subset is ignored rather than hanging', function () {
+                this.timeout(2000);
+                const xml = [
+                    '<!DOCTYPE topic [',
+                    '  <!ENTITY foo ' + '"a"'.repeat(30), // no closing '>' or ']'
+                    '<topic id="t1"><title>T</title></topic>',
+                ].join('\n');
+                const t0 = Date.now();
+                const diags = validate(xml);
+                assert.ok(Date.now() - t0 < 1000, 'validation should complete quickly, not hang');
+                assert.ok(Array.isArray(diags));
+            });
+        });
     });
 });


### PR DESCRIPTION
The XXE/entity-expansion pre-check (checkEntityExpansion, run
unconditionally as step 1 of validateDITADocument for every document)
used two backtracking regexes with a classic ReDoS shape — an
alternation of a quoted-string branch and a permissive catch-all
branch, wrapped in an unbounded quantifier:

  DOCTYPE_INTERNAL_SUBSET_RE:
    /<!DOCTYPE\s[\s\S]*?\[((\"[^\"]*\"|'[^']*'|[^\]])*)\]\s*>/i
  ENTITY_ANY_RE:
    /<!ENTITY\s+(%\s+)?(\S+)\s+(?:"[^"]*"|'[^']*'|[^>])*>/gi

On a DOCTYPE with no internal subset, DOCTYPE_INTERNAL_SUBSET_RE's lazy
`[\s\S]*?` doesn't stop at the DOCTYPE's own closing '>' — it keeps
searching the rest of the document for the next '[' anywhere at all.
A real-world DITA topic containing a <codeblock> with JSON content
(nested brackets + several quoted "key": "value" pairs) supplies
exactly that '[', and the subsequent inner alternation then has
combinatorially many ways to partition the quoted/unquoted content
while failing to find the required ']>' — pinning a CPU core
indefinitely on an ordinary, well-formed document. Confirmed
reproducing the exact fixture from the issue: the regex alone hung
past a 15s timeout on a 700-byte string.

Fix: replace both regexes with linear single-pass scanners
(extractDoctypeInternalSubset / extractBracketedSubset) that track
quote state and bracket depth by hand instead of backtracking, and
narrow the entity-counting regex to a plain `<!ENTITY` occurrence
count (only ever used for counting, so it never needed the
alternation in the first place). Neither can backtrack, so both are
immune to this class of input by construction — and, as a side
effect of doing the scan correctly, a '[' outside the DOCTYPE
declaration itself can no longer be mistaken for the start of an
internal subset.

All existing entity-expansion/XXE tests continue to pass unchanged,
including the quote-awareness regression test ("]> in value does not
bypass security checks on later entities"). Added regression tests
covering: the exact issue-125 fixture, a DOCTYPE-less bracket-heavy
document, and a malformed/unterminated internal subset — all now
complete in milliseconds instead of hanging.