### PR TITLE
Bump version to 0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the "DitaCraft" extension will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.1] - 2026-08-19
+
+### Changed
+
+- Version bump to exercise the [Auto Tag Release](.github/workflows/auto-tag.yml) GitHub Action, which tags and publishes a release whenever a version bump to `package.json` lands on `main`.
+
 ## [0.9.0] - 2026-08-15
 
 The full [v0.9.0 implementation plan](docs/V0.9-IMPLEMENTATION-PLAN.md) — every prioritized item shipped, plus two of three Backlog items taken on as natural follow-ons (Import from Markdown/HTML deferred, as the one item genuinely needing a design spike first).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ditacraft",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ditacraft",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.117.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ditacraft",
   "displayName": "DitaCraft",
   "description": "Best way to edit and publish your DITA files - Complete DITA editing and publishing solution for VS Code",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "publisher": "JeremyJeanne",
   "author": {
     "name": "Jeremy Jeanne",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ditacraft-lsp-server",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ditacraft-lsp-server",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "dependencies": {
         "fast-xml-parser": "^5.5.12",
         "salve-annos": "^1.2.4",

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ditacraft-lsp-server",
   "description": "DitaCraft DITA Language Server",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "private": true,
   "main": "./out/server.js",
   "scripts": {


### PR DESCRIPTION
Triggers the Auto Tag Release GitHub Action, which tags and publishes
a release once the version bump lands on main.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Xuib5CxwosrTXnhxSNaLUJ