### PR TITLE
fix(build): bump engines.vscode to match @types/vscode 1.134.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,12 +24,12 @@
         "@types/mocha": "^10.0.1",
         "@types/node": "^26.2.0",
         "@types/sinon": "^22.0.0",
-        "@types/vscode": "^1.125.0",
+        "@types/vscode": "^1.134.0",
         "@vscode/test-electron": "^3.1.0",
         "@vscode/vsce": "^3.9.2",
         "c8": "^12.0.0",
         "esbuild": "^0.28.2",
-        "eslint": "^10.8.1",
+        "eslint": "^10.9.0",
         "glob": "^13.0.1",
         "mocha": "^11.8.0",
         "npm-run-all": "^4.1.5",
@@ -39,7 +39,7 @@
         "typescript-eslint": "^8.67.0"
       },
       "engines": {
-        "vscode": "^1.125.0"
+        "vscode": "^1.134.0"
       }
     },
     "node_modules/@ai-sdk/anthropic": {
@@ -2009,6 +2009,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -2030,6 +2031,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -2051,6 +2053,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -2072,6 +2075,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -2093,6 +2097,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -2114,6 +2119,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -2135,6 +2141,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -2156,6 +2163,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -2177,6 +2185,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -2198,6 +2207,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -2219,6 +2229,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -3276,9 +3287,9 @@
       "optional": true
     },
     "node_modules/@types/vscode": {
-      "version": "1.125.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.125.0.tgz",
-      "integrity": "sha512-0icm/ZQAaism87P0ekHqi4/Ju9du+Tm0RUW+y7vqRsxY2cY0FNRX1nAnaW7nT6npPt2tfHiheZ55Zm9UhqonFA==",
+      "version": "1.134.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.134.0.tgz",
+      "integrity": "sha512-NDEu0hg4sF7+vvFsADsktqUJ6f80LHSZvVK2Ovo1XiQ0/VHck1O3zst+ZZyVA/uvz6vo6LcuoqU2q48YMqOwWw==",
       "dev": true,
       "license": "MIT"
     },
@@ -6057,9 +6068,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.8.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.1.tgz",
-      "integrity": "sha512-wqA7W2jbsC/BnV9Iv1UZpKVFkO1AdNoSmYW8NWG4HNOBbkAMvIqDZ27pI2f07dqn583NcIC44ckjAcOXDL1QbQ==",
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.9.1.tgz",
+      "integrity": "sha512-9VaAkDURekixUQJy0oJYl2DcN6oKMfxay7XzaGYAWQwsb6qfKf+x76R2k1L8kb1boc+FyCAaTA9GmiKaaiaF+A==",
       "dev": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/jyjeanne/ditacraft#readme",
   "engines": {
-    "vscode": "^1.125.0"
+    "vscode": "^1.134.0"
   },
   "categories": [
     "Programming Languages",
@@ -1071,12 +1071,12 @@
     "@types/mocha": "^10.0.1",
     "@types/node": "^26.2.0",
     "@types/sinon": "^22.0.0",
-    "@types/vscode": "^1.125.0",
+    "@types/vscode": "^1.134.0",
     "@vscode/test-electron": "^3.1.0",
     "@vscode/vsce": "^3.9.2",
     "c8": "^12.0.0",
     "esbuild": "^0.28.2",
-    "eslint": "^10.8.1",
+    "eslint": "^10.9.0",
     "glob": "^13.0.1",
     "mocha": "^11.8.0",
     "npm-run-all": "^4.1.5",


### PR DESCRIPTION
vsce package failed with "@types/vscode ^1.134.0 greater than
engines.vscode ^1.125.0" because the dev-dependencies Dependabot
group bumped @types/vscode and eslint without a matching engines
bump (see run 32790681738 / job 97632506770 on PR #128).

Apply the same dependency bumps directly and raise engines.vscode
to ^1.134.0 to match, since @types/vscode must never declare a
newer VS Code API surface than the extension claims to support.

- @types/vscode: ^1.125.0 -> ^1.134.0
- eslint: ^10.8.1 -> ^10.9.0
- engines.vscode: ^1.125.0 -> ^1.134.0

Verified npm run compile, npm run lint, and vsce package all pass.